### PR TITLE
Switch to PR workflow with CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,40 @@
+language: en-US
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+  path_instructions:
+    - path: "src/renderer/**"
+      instructions: |
+        - NEVER use React inline styles (style={{}}). All styling must use Tailwind CSS utility classes.
+        - Use shadcn/ui + Radix UI for interactive components (buttons, modals, dialogs).
+        - All animations must use Framer Motion with spring physics (type: "spring"). Never use linear transitions or duration-based timing.
+        - Use Zustand for state management. No React Context for state.
+    - path: "src/main/**"
+      instructions: |
+        - Do NOT use setIgnoreMouseEvents. Use content-tight window sizing instead.
+        - Do NOT use Electron vibrancy. Use CSS backgrounds.
+        - Do NOT use titleBarStyle with frame:false.
+        - Window must use transparent: true, frame: false, hasShadow: true.
+    - path: "src/preload/**"
+      instructions: |
+        - All IPC channels must be typed via the IPC enum in shared/types.ts.
+        - The renderer communicates with main ONLY through the window.clui API.
+    - path: "e2e/**"
+      instructions: |
+        - Every feature must have E2E test coverage using Playwright.
+        - Use seedFixture() or freshStart() for test state setup.
+        - Screenshots on failure for debugging.
+    - path: "docs/**"
+      instructions: |
+        - docs/ is the PUBLIC documentation website (VitePress). Every file here deploys to GitHub Pages.
+        - No date-stamped session logs. No internal working notes.
+        - Keep language human and direct. Avoid AI vocabulary (comprehensive, leverage, seamlessly).
+chat:
+  auto_reply: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,10 +244,36 @@ These CLUI-specific files should be removed:
 
 ## Git Workflow
 
-- Commit at each working milestone
-- Branch: `main` (no feature branches for MLP)
-- Test before commit: `npm run test && npm run test:e2e`
-- Never commit with failing tests
+**All changes go through pull requests. Never push directly to `main`.**
+
+1. Create a feature branch from `main`: `git checkout -b feat/my-change`
+2. Commit at each working milestone with clear messages
+3. Test before pushing: `npm run test && npm run test:e2e`
+4. Never push with failing tests
+5. Open a PR against `main` — CodeRabbit will auto-review
+6. Address CodeRabbit feedback before merging
+7. Squash-merge PRs to keep `main` history clean
+
+### Branch naming
+
+| Prefix | Use |
+|--------|-----|
+| `feat/` | New features |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation only |
+| `chore/` | Build, CI, tooling |
+| `refactor/` | Code restructuring (no behavior change) |
+
+### CodeRabbit
+
+CodeRabbit reviews every PR automatically. It checks for:
+- Inline styles (must use Tailwind)
+- Missing E2E test coverage
+- IPC type safety
+- Animation physics (spring only, no linear)
+- CLAUDE.md rule violations
+
+Fix CodeRabbit comments before merging. If a comment is a false positive, reply explaining why.
 
 ## Known Pitfalls (from prior runs)
 <!-- Auto-injected by openspec-loki-loop. Do not edit manually. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,64 +1,78 @@
-# Contributing to Clui CC
+# Contributing to Showtime
 
-Thanks for your interest in contributing! Clui CC is a desktop overlay for Claude Code, and we welcome bug reports, feature ideas, and pull requests.
+Thanks for your interest in contributing! Showtime is an ADHD-friendly macOS day planner built on the SNL Day Framework.
 
-## Getting Started
+## Getting started
 
-1. Make sure you have the [prerequisites](README.md#prerequisites) installed (macOS, Xcode CLT, Node.js 18+, Claude Code CLI 2.1+)
-2. Fork and clone the repo:
+1. Fork and clone:
    ```bash
-   git clone https://github.com/<your-username>/clui-cc.git
-   cd clui-cc
+   git clone https://github.com/<your-username>/showtime.git
+   cd showtime
    ```
-3. Check your environment (optional but recommended):
-   ```bash
-   npm run doctor
-   ```
-4. Install dependencies:
+2. Install dependencies:
    ```bash
    npm install
    ```
-   > If `npm install` fails, run `npm run doctor` to see which dependency is missing.
-5. Start the dev server:
+3. Start dev mode:
    ```bash
    npm run dev
    ```
-6. Make your changes in `src/`
-7. Verify your changes build cleanly:
-   ```bash
-   npm run build
-   ```
 
-## Development Tips
+Requires **macOS** and **Node.js 20+**.
 
-- **Main process** changes (`src/main/`) require a full restart (`Ctrl+C` then `npm run dev`).
+## Development tips
+
+- **Main process** changes (`src/main/`) require a full restart.
 - **Renderer** changes (`src/renderer/`) hot-reload automatically.
-- Set `CLUI_DEBUG=1` to enable verbose main-process logging to `~/.clui-debug.log`.
-- The app creates a transparent, content-tight floating window. Use `⌥ + Space` to toggle visibility (fallback: `Cmd+Shift+K`).
+- Toggle the window with `Opt+Space` (fallback: `Cmd+Shift+K`).
+- Dev reset: `Cmd+Shift+R` clears all state and reloads.
 
-## Code Style
+## Pull request workflow
 
-- TypeScript strict mode is enforced.
-- Use `useColors()` hook for all color references — never hardcode color values.
-- Zustand selectors should be narrow and use custom equality functions for performance.
-- Prefer editing existing files over creating new ones.
+All changes go through PRs. No direct pushes to `main`.
 
-## Pull Requests
+1. Create a branch: `git checkout -b feat/my-change`
+2. Make your changes
+3. Run tests: `npm run test && npm run build && npm run test:e2e`
+4. Push and open a PR against `main`
+5. **CodeRabbit** will auto-review your PR — address its feedback
+6. Get a human review
+7. Squash-merge when approved
 
-1. Create a feature branch from `main`.
-2. Keep PRs focused — one concern per PR.
-3. Include a brief description of what changed and why.
-4. Ensure `npm run build` passes with zero errors.
+### Branch naming
 
-## Reporting Bugs
+- `feat/` — new features
+- `fix/` — bug fixes
+- `docs/` — documentation
+- `chore/` — build, CI, tooling
+- `refactor/` — restructuring without behavior change
+
+## Code style
+
+These are non-negotiable (CodeRabbit enforces them):
+
+- **No inline styles.** Use Tailwind CSS utility classes, never `style={{}}`.
+- **shadcn/ui for interactive components.** Buttons, modals, dialogs — use the primitives.
+- **Spring physics only.** Framer Motion with `type: "spring"`. No linear transitions.
+- **Zustand for state.** No React Context for state management.
+- **Typed IPC.** All channels go through the `IPC` enum and `window.clui` bridge.
+- **E2E tests required.** Every feature needs Playwright coverage.
+
+See [CLAUDE.md](CLAUDE.md) for the full rule set.
+
+## Reporting bugs
 
 Open an issue with:
 - macOS version
 - Node.js version (`node --version`)
-- Claude Code CLI version (`claude --version`)
 - Steps to reproduce
 - Expected vs. actual behavior
+- Screenshots if it's a visual bug
 
-## Security
+## Documentation
 
-If you discover a security vulnerability, please report it privately. See [SECURITY.md](SECURITY.md).
+`docs/` is the public VitePress site. Internal notes go in `docs-internal/` (gitignored). See CLAUDE.md "Documentation Rules" for details.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- Update CLAUDE.md: require PRs for all changes, branch naming conventions, CodeRabbit review rules
- Add `.coderabbit.yaml` with path-specific instructions matching CLAUDE.md rules (no inline styles, spring physics, typed IPC, E2E required)
- Rewrite CONTRIBUTING.md for Showtime (was still the old Clui CC version)
- Branch protection enabled on `main` (require PRs, dismiss stale reviews)

## Test plan

- [ ] CodeRabbit picks up this PR and reviews it
- [ ] Direct push to `main` is blocked
- [ ] New PRs get auto-reviewed with path-specific instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines and development workflow documentation.
  * Added development configuration file for automated code review settings.

* **Chores**
  * Updated project naming across configuration and documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->