### PR TITLE
fix: Go Live button, calendar flicker cache, visual DPI normalization, help dialog

### DIFF
--- a/e2e/onboarding.test.ts
+++ b/e2e/onboarding.test.ts
@@ -155,7 +155,7 @@ test.describe('Onboarding (#15)', () => {
     await screenshot(page, 'onboarding-09-back')
   })
 
-  test('Help button re-triggers onboarding', async ({ mainPage: page }) => {
+  test('Help button opens help dialog', async ({ mainPage: page }) => {
     await page.evaluate(() => {
       localStorage.setItem('showtime-onboarding-complete', 'true')
       localStorage.removeItem('showtime-show-state')
@@ -167,12 +167,13 @@ test.describe('Onboarding (#15)', () => {
       await helpBtn.click()
       await page.waitForTimeout(1000)
 
-      const welcomeTitle = page.getByText('Welcome to the Show')
-      await expect(welcomeTitle).toBeVisible({ timeout: 5000 })
+      const helpTitle = page.getByText('How Showtime Works')
+      await expect(helpTitle).toBeVisible({ timeout: 5000 })
 
+      // Onboarding should NOT re-trigger
       const flag = await page.evaluate(() => localStorage.getItem('showtime-onboarding-complete'))
-      expect(flag).toBeNull()
+      expect(flag).toBe('true')
     }
-    await screenshot(page, 'onboarding-10-help-retrigger')
+    await screenshot(page, 'onboarding-10-help-dialog')
   })
 })

--- a/e2e/writers-room.test.ts
+++ b/e2e/writers-room.test.ts
@@ -64,7 +64,14 @@ test.describe('7.3 — Writer\'s Room Flow', () => {
     const goLiveButton = page.locator('button').filter({ hasText: /live/i }).first()
     if (await goLiveButton.isVisible({ timeout: 3000 }).catch(() => false)) {
       await goLiveButton.click()
-      await page.waitForTimeout(3000)
+      await page.waitForTimeout(2000)
+
+      // Going Live transition now requires clicking the "Go Live" button
+      const goLiveConfirm = page.getByTestId('go-live-button')
+      if (await goLiveConfirm.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await goLiveConfirm.click()
+        await page.waitForTimeout(1000)
+      }
       await screenshot(page, '06-going-live')
     }
   })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     { name: 'smoke', testMatch: /app-launch|onboarding/ },
     { name: 'core-flow', testMatch: /writers-room|live-show|strike-reset/ },
     { name: 'data-views', testMatch: /data-layer|temporal|temporal-copy|view-tiers|history/ },
-    { name: 'visual', testMatch: /visual-regression|visual-validation|consistency/ },
+    { name: 'visual', testMatch: /visual-regression|visual-validation|consistency/, use: { deviceScaleFactor: 1 } },
   ],
   testIgnore: ['showtime.test.ts'],
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -18,6 +18,7 @@ import { HistoryView } from './views/HistoryView'
 import { SettingsView } from './views/SettingsView'
 import { OnboardingView } from './views/OnboardingView'
 import { BeatCheckModal } from './components/BeatCheckModal'
+import { HelpDialog } from './components/HelpDialog'
 import type { ViewTier } from '../shared/types'
 
 // View modes that the IPC bridge accepts for window sizing
@@ -59,6 +60,7 @@ export default function App() {
   })
   const [showHistory, setShowHistory] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
+  const [showHelp, setShowHelp] = useState(false)
 
   // ─── Listen for tray-triggered reset ───
   const resetShow = useShowStore((s) => s.resetShow)
@@ -149,10 +151,9 @@ export default function App() {
     }
   }, [enterWritersRoom])
 
-  // ─── Help button re-triggers onboarding ───
+  // ─── Help button opens help dialog ───
   const handleHelpClick = useCallback(() => {
-    localStorage.removeItem('showtime-onboarding-complete')
-    setShowOnboarding(true)
+    setShowHelp(true)
   }, [])
 
   // ─── View routing ───
@@ -226,6 +227,7 @@ export default function App() {
       <AnimatePresence mode="wait">
         {renderView()}
       </AnimatePresence>
+      <HelpDialog open={showHelp} onOpenChange={setShowHelp} />
       <BeatCheckModal />
     </div>
   )

--- a/src/renderer/components/HelpDialog.tsx
+++ b/src/renderer/components/HelpDialog.tsx
@@ -1,0 +1,57 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '../ui/dialog'
+
+interface HelpDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function HelpDialog({ open, onOpenChange }: HelpDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>How Showtime Works</DialogTitle>
+          <DialogDescription>Your day is a live show.</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 text-sm text-txt-secondary">
+          <section>
+            <h3 className="font-body font-semibold text-txt-primary mb-1">Acts</h3>
+            <p>Each task is an Act in your show. Start an act, work until the timer ends, then move on.</p>
+          </section>
+
+          <section>
+            <h3 className="font-body font-semibold text-txt-primary mb-1">Beats</h3>
+            <p>Moments of presence during an act. When the Beat Check appears, pause and notice how you feel. Lock it or skip — no wrong answer.</p>
+          </section>
+
+          <section>
+            <h3 className="font-body font-semibold text-txt-primary mb-1">Show Phases</h3>
+            <ul className="space-y-1 ml-4 list-disc">
+              <li><span className="text-txt-primary">Dark Studio</span> — before the show starts</li>
+              <li><span className="text-txt-primary">Writer&apos;s Room</span> — plan your lineup</li>
+              <li><span className="text-txt-primary">ON AIR</span> — you&apos;re live, working acts</li>
+              <li><span className="text-txt-primary">Intermission</span> — rest between acts (free)</li>
+              <li><span className="text-txt-primary">Strike</span> — show&apos;s over, see your verdict</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3 className="font-body font-semibold text-txt-primary mb-1">Keyboard Shortcuts</h3>
+            <ul className="space-y-1 font-mono text-xs">
+              <li><kbd className="bg-surface-hover px-1.5 py-0.5 rounded">Space</kbd> — pause / resume timer</li>
+              <li><kbd className="bg-surface-hover px-1.5 py-0.5 rounded">S</kbd> — skip current act</li>
+              <li><kbd className="bg-surface-hover px-1.5 py-0.5 rounded">⌘ ,</kbd> — settings</li>
+            </ul>
+          </section>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -250,6 +250,10 @@ export const useSessionStore = create<State>((set, get) => ({
               )
               if (hasCalendar) {
                 useShowStore.getState().setCalendarAvailable(true)
+                localStorage.setItem('showtime-gcal-connected', 'true')
+              } else {
+                localStorage.removeItem('showtime-gcal-connected')
+                useShowStore.getState().setCalendarAvailable(false)
               }
             }
             if (!event.isWarmup) {

--- a/src/renderer/stores/showStore.ts
+++ b/src/renderer/stores/showStore.ts
@@ -140,7 +140,7 @@ const initialState: ShowStoreState = {
   writersRoomStep: 'energy',
   writersRoomEnteredAt: null,
   breathingPauseEndAt: null,
-  calendarAvailable: false,
+  calendarAvailable: typeof localStorage !== 'undefined' && localStorage.getItem('showtime-gcal-connected') === 'true',
   calendarEnabled: typeof localStorage !== 'undefined' && localStorage.getItem('showtime-calendar-enabled') === 'true',
 }
 

--- a/src/renderer/views/GoingLiveTransition.tsx
+++ b/src/renderer/views/GoingLiveTransition.tsx
@@ -1,6 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { OnAirIndicator } from '../components/OnAirIndicator';
+import { Button } from '../ui/button';
 import { playAudioCue } from '../hooks/useAudio';
 
 interface GoingLiveTransitionProps {
@@ -8,6 +9,8 @@ interface GoingLiveTransitionProps {
 }
 
 export function GoingLiveTransition({ onComplete }: GoingLiveTransitionProps) {
+  const [showButton, setShowButton] = useState(false);
+
   const formattedDate = new Date().toLocaleDateString('en-US', {
     weekday: 'long',
     year: 'numeric',
@@ -17,9 +20,9 @@ export function GoingLiveTransition({ onComplete }: GoingLiveTransitionProps) {
 
   useEffect(() => {
     playAudioCue('going-live');
-    const timer = setTimeout(onComplete, 2500);
+    const timer = setTimeout(() => setShowButton(true), 1800);
     return () => clearTimeout(timer);
-  }, [onComplete]);
+  }, []);
 
   return (
     <div className="fixed inset-0 bg-studio-bg flex flex-col items-center justify-center z-50">
@@ -51,6 +54,24 @@ export function GoingLiveTransition({ onComplete }: GoingLiveTransitionProps) {
       >
         The studio lights are on.
       </motion.p>
+
+      {showButton && (
+        <motion.div
+          initial={{ scale: 0.8, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+          className="mt-8"
+        >
+          <Button
+            variant="accent"
+            className="text-lg px-8 py-3 font-bold"
+            onClick={onComplete}
+            data-testid="go-live-button"
+          >
+            Go Live
+          </Button>
+        </motion.div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **#50 Going Live button**: Transition no longer auto-advances after 2.5s. A "Go Live" button with spring animation appears after the intro, requiring deliberate user action to start the show.
- **#49 Calendar flicker**: Google Calendar connection status is cached in `localStorage`. On Writer's Room mount, the cached value is read instantly so the "Connect" banner doesn't flash for ~1s while the async check runs.
- **#46 DPI mismatch**: Visual regression project in Playwright config now sets `deviceScaleFactor: 1` so screenshots are consistent regardless of display scaling. Baselines need regenerating with `--update-snapshots`.
- **#44 Help dialog**: The `?` button now opens a Help dialog (shadcn/ui Dialog) with show phases, acts, beats, and keyboard shortcuts instead of re-triggering onboarding.

## Test plan

- [x] All 235 Vitest unit tests pass
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] E2E test updated: writers-room "can go live" now clicks the Go Live button
- [x] E2E test updated: onboarding "Help button opens help dialog" verifies dialog appears and onboarding flag preserved
- [ ] Visual regression baselines need regeneration after merge (`npx playwright test --update-snapshots --project=visual`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Help dialog with documentation about Acts, Beats, Show Phases, and Keyboard Shortcuts
  * Calendar connection state now persists across sessions

* **Bug Fixes**
  * Help button now opens help dialog instead of re-triggering onboarding

* **Tests**
  * Updated E2E test configurations and timing adjustments for onboarding and going live flows
  * Updated visual test configuration for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->