### PR TITLE
chore: garden CLAUDE.md — fix stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file is the source of truth for ALL agents working in this codebase.
 ## Active Specification
 
 - **Spec:** `.claude/specs/showtime-v2/` (active)
-- **Superseded:** `.claude/specs/showtime-snl-planner/` (v1 — thin product context, do not use)
+- **Superseded:** `.claude/specs/showtime-snl-planner/` (v1 — archived, do not use)
 
 ## Product Context
 
@@ -27,7 +27,7 @@ Read `docs/plans/product-context.md` for the full product vision. Key points:
 Showtime (Electron App, macOS only)
 ├── Main Process (Node.js)
 │   ├── claude/              ← KEEP: subprocess management (RunManager, ControlPlane, StreamParser)
-│   ├── window management    ← KEEP: NSPanel, always-on-top, click-through
+│   ├── window management    ← NSPanel, always-on-top, content-tight sizing
 │   └── IPC handlers         ← KEEP: notification triggers, theme sync
 ├── Preload (contextBridge)
 │   └── window.clui API      ← KEEP: typed IPC bridge, strict process isolation
@@ -212,7 +212,7 @@ Full reference: `docs/plans/design-system.md`
 |------|------|-------|
 | Dark Studio | Full window | Empty stage with spotlight |
 | Writer's Room | 560 x 680px | Energy → Plan → Lineup → "WE'RE LIVE!" |
-| Pill | 320 x 48px | Floating, always-on-top, rounded-full |
+| Pill | 320 x 64px | Floating, always-on-top, rounded-full |
 | Expanded | 560 x 620px | Timer hero + lineup sidebar + ON AIR bar |
 | Beat Check | 380px card | Centered modal with spotlight |
 | Intermission | 560 x 500px | "WE'LL BE RIGHT BACK" card |
@@ -224,15 +224,9 @@ Full reference: `docs/plans/design-system.md`
 The definitive UI mockup is at `docs/mockups/direction-4-the-show.html`.
 Open it in a browser to see all views. When implementing, match this mockup.
 
-## Files to Delete (CLUI Dead Weight)
+## CLUI Legacy Notes
 
-These CLUI-specific files should be removed:
-- `src/renderer/components/ConversationView.tsx` — General chat rendering
-- `src/renderer/components/InputBar.tsx` — Rich input (rebuild simplified for Showtime)
-- `src/renderer/components/PermissionCard.tsx` — Keep but simplify
-- `src/renderer/components/AttachmentChips.tsx` — Not needed
-- `src/renderer/components/SlashCommandMenu.tsx` — Not needed
-- `src/renderer/components/PopoverLayer.tsx` — Replace with shadcn/ui
+The original CLUI components (ConversationView, InputBar, PermissionCard, AttachmentChips, SlashCommandMenu, PopoverLayer) have been removed. If you find any remaining inline `style={{}}` patterns, they're CLUI leftovers — replace with Tailwind classes.
 
 ## Documentation Rules
 


### PR DESCRIPTION
## Summary

- Remove "Files to Delete" section — all 6 CLUI components already deleted
- Fix pill view dimensions: 320x48 → 320x64 (changed in #43 fix)
- Fix architecture tree: "click-through" → "content-tight sizing" (click-through was removed)
- Simplify superseded spec note

## Test plan

- [ ] No code changes — docs only
- [ ] CLAUDE.md references still point to existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation with archived status and legacy component notes.
  * Refined architecture specifications and updated component dimensions.
  * Added guidance for modernizing styling approach.

**Note:** No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->