### PR TITLE
fix: graceful calendar import fallback + parser resilience (#55)

### DIFF
--- a/src/__tests__/lineupParser.test.ts
+++ b/src/__tests__/lineupParser.test.ts
@@ -1,19 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import type { ShowLineup } from '../shared/types'
-
-// Extract the parser function to test in isolation
-// (same logic as ChatPanel.tryParseLineup)
-function tryParseLineup(text: string): ShowLineup | null {
-  const match = text.match(/```showtime-lineup\s*\n([\s\S]*?)```/)
-  if (!match) return null
-  try {
-    const parsed = JSON.parse(match[1])
-    if (parsed.acts && Array.isArray(parsed.acts) && typeof parsed.beatThreshold === 'number') {
-      return parsed as ShowLineup
-    }
-  } catch {}
-  return null
-}
+import { tryParseLineup } from '../renderer/lib/lineup-parser'
 
 describe('tryParseLineup', () => {
   it('parses valid showtime-lineup JSON block', () => {
@@ -75,11 +61,11 @@ Good luck today!`
   })
 
   it('ignores other code blocks', () => {
-    const text = '```json\n{"acts": [], "beatThreshold": 3}\n```'
+    const text = '```python\nprint("hello")\n```'
     expect(tryParseLineup(text)).toBeNull()
   })
 
-  it('extracts first lineup when multiple blocks exist', () => {
+  it('prefers the last lineup block when multiple exist', () => {
     const text = `\`\`\`showtime-lineup
 {"acts": [{"name": "First", "sketch": "A", "durationMinutes": 30}], "beatThreshold": 1, "openingNote": "first"}
 \`\`\`
@@ -89,7 +75,7 @@ Some text
 \`\`\``
 
     const result = tryParseLineup(text)
-    expect(result!.acts[0].name).toBe('First')
+    expect(result!.acts[0].name).toBe('Second')
   })
 
   it('handles lineup with optional act fields', () => {
@@ -114,5 +100,174 @@ Some text
     expect(result).not.toBeNull()
     expect(result!.acts).toHaveLength(0)
     expect(result!.beatThreshold).toBe(0)
+  })
+
+  // ─── Resilience: tool call stripping ───
+
+  it('strips tool_use blocks before parsing lineup', () => {
+    const text = `I'll check your calendar first.
+
+\`\`\`tool_use
+{"name": "gcal_list_events", "input": {"date": "2026-03-25"}}
+\`\`\`
+
+Here are your events. Now let me build the lineup:
+
+\`\`\`showtime-lineup
+{
+  "acts": [
+    { "name": "Standup", "sketch": "Admin", "durationMinutes": 15 },
+    { "name": "Deep Focus", "sketch": "Deep Work", "durationMinutes": 90 }
+  ],
+  "beatThreshold": 2,
+  "openingNote": "Calendar synced!"
+}
+\`\`\``
+
+    const result = tryParseLineup(text)
+    expect(result).not.toBeNull()
+    expect(result!.acts).toHaveLength(2)
+    expect(result!.acts[0].name).toBe('Standup')
+    expect(result!.openingNote).toBe('Calendar synced!')
+  })
+
+  it('strips tool_result blocks before parsing lineup', () => {
+    const text = `\`\`\`tool_result
+{"events": [{"summary": "Team standup", "start": "09:00"}]}
+\`\`\`
+
+Based on your calendar:
+
+\`\`\`showtime-lineup
+{
+  "acts": [{ "name": "Team standup", "sketch": "Admin", "durationMinutes": 30 }],
+  "beatThreshold": 1,
+  "openingNote": "One meeting day"
+}
+\`\`\``
+
+    const result = tryParseLineup(text)
+    expect(result).not.toBeNull()
+    expect(result!.acts[0].name).toBe('Team standup')
+  })
+
+  it('strips tool_call blocks before parsing lineup', () => {
+    const text = `\`\`\`tool_call
+{"function": "calendar_search"}
+\`\`\`
+
+\`\`\`showtime-lineup
+{
+  "acts": [{ "name": "Focus", "sketch": "Deep Work", "durationMinutes": 60 }],
+  "beatThreshold": 1,
+  "openingNote": "Focused day"
+}
+\`\`\``
+
+    const result = tryParseLineup(text)
+    expect(result).not.toBeNull()
+    expect(result!.acts[0].name).toBe('Focus')
+  })
+
+  // ─── Resilience: fallback JSON parsing ───
+
+  it('falls back to json code block when no showtime-lineup fence', () => {
+    const text = `Here's your lineup:
+
+\`\`\`json
+{
+  "acts": [
+    { "name": "Workout", "sketch": "Exercise", "durationMinutes": 45 }
+  ],
+  "beatThreshold": 1,
+  "openingNote": "Get moving!"
+}
+\`\`\``
+
+    const result = tryParseLineup(text)
+    expect(result).not.toBeNull()
+    expect(result!.acts[0].name).toBe('Workout')
+  })
+
+  it('falls back to bare JSON object with acts array', () => {
+    const text = `Here's your lineup for today:
+
+{
+  "acts": [
+    { "name": "Email triage", "sketch": "Admin", "durationMinutes": 30 }
+  ],
+  "beatThreshold": 1,
+  "openingNote": "Quick start"
+}`
+
+    const result = tryParseLineup(text)
+    expect(result).not.toBeNull()
+    expect(result!.acts[0].name).toBe('Email triage')
+  })
+
+  it('prefers showtime-lineup block over json fallback', () => {
+    const text = `\`\`\`json
+{"acts": [{"name": "Wrong", "sketch": "A", "durationMinutes": 10}], "beatThreshold": 1, "openingNote": "wrong"}
+\`\`\`
+
+Actually, let me format that properly:
+
+\`\`\`showtime-lineup
+{"acts": [{"name": "Right", "sketch": "B", "durationMinutes": 20}], "beatThreshold": 2, "openingNote": "right"}
+\`\`\``
+
+    const result = tryParseLineup(text)
+    expect(result!.acts[0].name).toBe('Right')
+  })
+
+  it('handles tool error followed by retry with valid lineup', () => {
+    const text = `I'll check your calendar.
+
+\`\`\`tool_use
+{"name": "gcal_list_events", "input": {"date": "2026-03-25"}}
+\`\`\`
+
+\`\`\`tool_result
+{"error": "Calendar MCP tool not available"}
+\`\`\`
+
+No worries, I'll build the lineup from your text input:
+
+\`\`\`showtime-lineup
+{
+  "acts": [
+    { "name": "Morning Focus", "sketch": "Deep Work", "durationMinutes": 90 }
+  ],
+  "beatThreshold": 1,
+  "openingNote": "No calendar needed"
+}
+\`\`\``
+
+    const result = tryParseLineup(text)
+    expect(result).not.toBeNull()
+    expect(result!.acts[0].name).toBe('Morning Focus')
+  })
+
+  it('returns null when bare JSON does not have acts array', () => {
+    const text = '{"foo": "bar", "baz": [1, 2, 3]}'
+    expect(tryParseLineup(text)).toBeNull()
+  })
+
+  it('falls back to unfenced code block', () => {
+    const text = `Here's your lineup:
+
+\`\`\`
+{
+  "acts": [
+    { "name": "Reading", "sketch": "Deep Work", "durationMinutes": 60 }
+  ],
+  "beatThreshold": 1,
+  "openingNote": "Quiet morning"
+}
+\`\`\``
+
+    const result = tryParseLineup(text)
+    expect(result).not.toBeNull()
+    expect(result!.acts[0].name).toBe('Reading')
   })
 })

--- a/src/renderer/lib/lineup-parser.ts
+++ b/src/renderer/lib/lineup-parser.ts
@@ -1,13 +1,52 @@
 import type { ShowLineup } from '../../shared/types'
 
+/**
+ * Strip tool_use / tool_result blocks that Claude may interleave when
+ * MCP tool calls (e.g. Google Calendar) precede the lineup output.
+ * These blocks look like: ```tool_use\n...\n``` or ```tool_result\n...\n```
+ */
+function stripToolBlocks(text: string): string {
+  return text.replace(/```(?:tool_use|tool_result|tool_call)\s*\n[\s\S]*?```/g, '')
+}
+
+function isValidLineup(obj: unknown): obj is ShowLineup {
+  if (!obj || typeof obj !== 'object') return false
+  const o = obj as Record<string, unknown>
+  return Array.isArray(o.acts) && typeof o.beatThreshold === 'number'
+}
+
 export function tryParseLineup(text: string): ShowLineup | null {
-  const match = text.match(/```showtime-lineup\s*\n([\s\S]*?)```/)
-  if (!match) return null
-  try {
-    const parsed = JSON.parse(match[1])
-    if (parsed.acts && Array.isArray(parsed.acts) && typeof parsed.beatThreshold === 'number') {
-      return parsed as ShowLineup
-    }
-  } catch {}
+  // Strip tool call blocks that may confuse the regex
+  const cleaned = stripToolBlocks(text)
+
+  // Try all showtime-lineup blocks, preferring the last one
+  // (Claude may retry after a tool failure, so the last block is most likely correct)
+  const blocks = [...cleaned.matchAll(/```showtime-lineup\s*\n([\s\S]*?)```/g)]
+  for (let i = blocks.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(blocks[i][1])
+      if (isValidLineup(parsed)) return parsed
+    } catch {}
+  }
+
+  // Fallback: look for any JSON object with an "acts" array in the text
+  // This handles cases where Claude omits the showtime-lineup fence
+  const jsonFallback = cleaned.match(/```(?:json)?\s*\n([\s\S]*?)```/)
+  if (jsonFallback) {
+    try {
+      const parsed = JSON.parse(jsonFallback[1])
+      if (isValidLineup(parsed)) return parsed
+    } catch {}
+  }
+
+  // Last resort: try to find a bare JSON object with "acts" in the text
+  const bareJson = cleaned.match(/\{[\s\S]*"acts"\s*:\s*\[[\s\S]*\][\s\S]*\}/)
+  if (bareJson) {
+    try {
+      const parsed = JSON.parse(bareJson[0])
+      if (isValidLineup(parsed)) return parsed
+    } catch {}
+  }
+
   return null
 }

--- a/src/renderer/views/WritersRoomView.tsx
+++ b/src/renderer/views/WritersRoomView.tsx
@@ -55,14 +55,20 @@ export function WritersRoomView() {
     return () => clearInterval(interval)
   }, [writersRoomEnteredAt])
 
-  const handleBuildLineup = () => {
+  const handleBuildLineup = (overrideCalendar?: boolean) => {
     if (!planText.trim()) return
     setIsSubmitting(true)
     setError(null)
 
-    const calendarInstruction = calendarEnabled && calendarAvailable
-      ? `IMPORTANT: First, check the user's Google Calendar for today's events using your calendar tools.
-Incorporate calendar events as acts in the lineup.
+    const useCalendar = overrideCalendar ?? calendarEnabled
+    const calendarInstruction = useCalendar && calendarAvailable
+      ? `IMPORTANT: First, try to check the user's Google Calendar for today's events using your calendar tools.
+If the calendar tool is unavailable, fails, or returns an error:
+- DO NOT mention the failure to the user
+- Generate the lineup from the user's text input only
+- This is normal — not all setups have calendar access
+
+If calendar events are found: incorporate them as acts in the lineup.
 For calendar events: use event title as act name, event duration as planned duration.
 Categorize: meetings/1:1s → "Admin", focus blocks → "Deep Work", gym → "Exercise", creative → "Creative", social → "Social".
 Add "(from calendar)" to the sketch field for calendar-sourced acts.
@@ -123,30 +129,55 @@ ${planText}`
     // Check for errors/completion without valid lineup
     if (tab.status === 'failed' || tab.status === 'dead') {
       setIsSubmitting(false)
-      setError('Claude couldn\'t generate a lineup. Try again?')
+      if (calendarEnabled && calendarAvailable) {
+        setError('Lineup generation failed. Try unchecking "Import calendar events" and trying again.')
+      } else {
+        setError('Claude couldn\'t generate a lineup. Try again?')
+      }
       return
     }
-  }, [tabs, activeTabId, isSubmitting, setLineup, setWritersRoomStep])
 
-  // Loading phase progression: initial → extended (10s) → timeout (30s)
+    // If completed/idle but no lineup parsed from response, show specific error
+    if (tab.status === 'completed' || tab.status === 'idle') {
+      const hasAssistantMessage = messages.some((m) => m.role === 'assistant' && !m.toolName)
+      if (hasAssistantMessage) {
+        setIsSubmitting(false)
+        if (calendarEnabled && calendarAvailable) {
+          setError('Lineup generation failed. Try unchecking "Import calendar events" and trying again.')
+        } else {
+          setError('Claude couldn\'t generate a lineup. Try again?')
+        }
+      }
+    }
+  }, [tabs, activeTabId, isSubmitting, setLineup, setWritersRoomStep, calendarEnabled, calendarAvailable])
+
+  // Loading phase progression: initial → extended → timeout
+  // Calendar tool calls add 3-10s, so extend timeout when calendar is enabled
+  const timeoutMs = calendarEnabled && calendarAvailable ? 60000 : 30000
+  const extendedMs = calendarEnabled && calendarAvailable ? 15000 : 10000
+
   useEffect(() => {
     if (!isSubmitting) {
       setLoadingPhase('initial')
       return
     }
 
-    const extendedTimer = setTimeout(() => setLoadingPhase('extended'), 10000)
+    const extendedTimer = setTimeout(() => setLoadingPhase('extended'), extendedMs)
     const timeoutTimer = setTimeout(() => {
       setLoadingPhase('timeout')
       setIsSubmitting(false)
-      setError('The writers need a coffee break. Try again?')
-    }, 30000)
+      if (calendarEnabled && calendarAvailable) {
+        setError('Calendar import took too long. Try without calendar or try again?')
+      } else {
+        setError('The writers need a coffee break. Try again?')
+      }
+    }, timeoutMs)
 
     return () => {
       clearTimeout(extendedTimer)
       clearTimeout(timeoutTimer)
     }
-  }, [isSubmitting])
+  }, [isSubmitting, timeoutMs, extendedMs, calendarEnabled, calendarAvailable])
 
   // ─── Lineup Refinement ───
 
@@ -325,7 +356,7 @@ Keep the same format as before. Only modify what the user asked for.`
                     </Button>
 
                     {error && (
-                      <div className="flex items-center gap-2 mt-2">
+                      <div className="flex flex-wrap items-center gap-2 mt-2">
                         <p className="text-xs text-onair">{error}</p>
                         <button
                           onClick={handleBuildLineup}
@@ -333,6 +364,18 @@ Keep the same format as before. Only modify what the user asked for.`
                         >
                           Try again
                         </button>
+                        {calendarEnabled && calendarAvailable && (
+                          <button
+                            onClick={() => {
+                              setCalendarEnabled(false)
+                              handleBuildLineup(false)
+                            }}
+                            className="text-xs text-accent hover:text-accent-dark underline"
+                            data-testid="retry-without-calendar"
+                          >
+                            Generate without calendar
+                          </button>
+                        )}
                       </div>
                     )}
 


### PR DESCRIPTION
## Summary

- **Fix 1 — Prompt fallback:** Calendar instruction now tells Claude to silently degrade when MCP tools are unavailable, generating lineup from text input only
- **Fix 2 — Parser resilience:** `tryParseLineup()` strips `tool_use`/`tool_result`/`tool_call` blocks, prefers last lineup block (handles retry after tool failure), and falls back to bare JSON objects
- **Fix 3 — MCP detection:** Already implemented via `event.tools` substring matching at session init (no changes needed)
- **Fix 4 — Better error messages:** Context-aware errors — when calendar is enabled, suggests unchecking calendar; includes "Generate without calendar" quick retry button
- **Fix 5 — Timeout handling:** Extended timeout from 30s → 60s when calendar import is enabled; "Still working..." indicator at 15s

## Test plan

- [x] 250 unit tests pass (9 new for parser resilience)
- [ ] Manual: test with Google Calendar MCP configured
- [ ] Manual: test with calendar toggle checked but MCP unavailable
- [ ] Manual: test "Generate without calendar" button after failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lineup parsing resilience with enhanced fallback strategies when primary parsing methods fail.
  * Enhanced error handling with calendar-specific messages when generation encounters issues.

* **New Features**
  * Added "Generate without calendar" retry button, allowing users to regenerate lineups without calendar data when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->