### PR TITLE
feat: pre-fetch calendar events on Writer's Room entry (#58)

### DIFF
--- a/e2e/writers-room.test.ts
+++ b/e2e/writers-room.test.ts
@@ -77,6 +77,51 @@ test.describe('7.3 — Writer\'s Room Flow', () => {
   })
 })
 
+test.describe('Calendar Prefetch (#58)', () => {
+  test('shows CalendarBanner when calendar MCP is not available', async ({ mainPage: page }) => {
+    await page.evaluate(() => {
+      localStorage.removeItem('showtime-gcal-connected')
+    })
+    await seedFixture(page, FIXTURES.writersRoom_plan)
+
+    const banner = page.getByTestId('calendar-banner')
+    await expect(banner).toBeVisible({ timeout: 5000 })
+    await screenshot(page, 'calendar-banner-no-mcp')
+  })
+
+  test('shows CalendarToggle when calendar MCP is available', async ({ mainPage: page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem('showtime-gcal-connected', 'true')
+      localStorage.setItem('showtime-calendar-enabled', 'true')
+    })
+    await seedFixture(page, FIXTURES.writersRoom_plan)
+
+    const toggle = page.getByTestId('calendar-toggle')
+    await expect(toggle).toBeVisible({ timeout: 5000 })
+
+    // Status label should be visible (may show fetching, idle, or status text)
+    const statusLabel = page.getByTestId('calendar-status')
+    await expect(statusLabel).toBeVisible({ timeout: 3000 })
+    await screenshot(page, 'calendar-toggle-with-status')
+  })
+
+  test('CalendarBanner can be dismissed', async ({ mainPage: page }) => {
+    await page.evaluate(() => {
+      localStorage.removeItem('showtime-gcal-connected')
+    })
+    await seedFixture(page, FIXTURES.writersRoom_plan)
+
+    const banner = page.getByTestId('calendar-banner')
+    await expect(banner).toBeVisible({ timeout: 5000 })
+
+    const dismissBtn = page.getByTestId('calendar-banner-dismiss')
+    await dismissBtn.click()
+    await page.waitForTimeout(500)
+    await expect(banner).not.toBeVisible()
+    await screenshot(page, 'calendar-banner-dismissed')
+  })
+})
+
 test.describe('Claude E2E Verification (#6, #13)', () => {
   test('Writer\'s Room generates real lineup via Claude (conditional)', async ({ mainPage: page }) => {
     await seedFixture(page, FIXTURES.writersRoom_plan)

--- a/src/__tests__/calendarPrefetch.test.ts
+++ b/src/__tests__/calendarPrefetch.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { tryParseCalendarEvents } from '../renderer/lib/calendar-parser'
+import { useShowStore } from '../renderer/stores/showStore'
+
+describe('tryParseCalendarEvents', () => {
+  it('parses valid JSON array of events', () => {
+    const text = `[
+  {"title": "Standup", "start": "09:00", "end": "09:15", "allDay": false},
+  {"title": "Lunch", "start": "12:00", "end": "13:00", "allDay": false}
+]`
+    const events = tryParseCalendarEvents(text)
+    expect(events).not.toBeNull()
+    expect(events).toHaveLength(2)
+    expect(events![0].title).toBe('Standup')
+    expect(events![1].start).toBe('12:00')
+  })
+
+  it('parses fenced JSON block', () => {
+    const text = `Here are your events:
+
+\`\`\`json
+[
+  {"title": "Team sync", "start": "10:00", "end": "10:30", "allDay": false}
+]
+\`\`\``
+    const events = tryParseCalendarEvents(text)
+    expect(events).not.toBeNull()
+    expect(events).toHaveLength(1)
+    expect(events![0].title).toBe('Team sync')
+  })
+
+  it('parses empty array', () => {
+    const text = '[]'
+    const events = tryParseCalendarEvents(text)
+    expect(events).not.toBeNull()
+    expect(events).toHaveLength(0)
+  })
+
+  it('parses empty array in fenced block', () => {
+    const text = 'No events found.\n\n```json\n[]\n```'
+    const events = tryParseCalendarEvents(text)
+    expect(events).not.toBeNull()
+    expect(events).toHaveLength(0)
+  })
+
+  it('returns null for invalid JSON', () => {
+    expect(tryParseCalendarEvents('not json at all')).toBeNull()
+  })
+
+  it('returns null for JSON object (not array)', () => {
+    expect(tryParseCalendarEvents('{"title": "test"}')).toBeNull()
+  })
+
+  it('returns null for array with invalid event shape', () => {
+    // Missing required fields
+    expect(tryParseCalendarEvents('[{"name": "test"}]')).toBeNull()
+  })
+
+  it('handles all-day events', () => {
+    const text = '[{"title": "Holiday", "start": "00:00", "end": "23:59", "allDay": true}]'
+    const events = tryParseCalendarEvents(text)
+    expect(events).not.toBeNull()
+    expect(events![0].allDay).toBe(true)
+  })
+
+  it('handles events with surrounding text', () => {
+    const text = `I found 2 events on your calendar today:
+
+[{"title": "1:1 with manager", "start": "14:00", "end": "14:30", "allDay": false}, {"title": "Gym", "start": "17:00", "end": "18:00", "allDay": false}]
+
+Let me know if you need anything else.`
+    const events = tryParseCalendarEvents(text)
+    expect(events).not.toBeNull()
+    expect(events).toHaveLength(2)
+  })
+
+  it('prefers fenced block over bare array', () => {
+    const text = `Some context [1, 2, 3]
+
+\`\`\`json
+[{"title": "Meeting", "start": "09:00", "end": "10:00", "allDay": false}]
+\`\`\``
+    const events = tryParseCalendarEvents(text)
+    expect(events).not.toBeNull()
+    expect(events).toHaveLength(1)
+    expect(events![0].title).toBe('Meeting')
+  })
+})
+
+describe('showStore calendar state', () => {
+  beforeEach(() => {
+    useShowStore.getState().resetShow()
+  })
+
+  it('initializes with idle fetch status and empty events', () => {
+    const state = useShowStore.getState()
+    expect(state.calendarFetchStatus).toBe('idle')
+    expect(state.calendarEvents).toEqual([])
+    expect(state.calendarFetchedAt).toBeNull()
+  })
+
+  it('setCalendarEvents updates events and status', () => {
+    const events = [
+      { title: 'Meeting', start: '10:00', end: '11:00', allDay: false },
+    ]
+    useShowStore.getState().setCalendarEvents(events)
+
+    const state = useShowStore.getState()
+    expect(state.calendarEvents).toEqual(events)
+    expect(state.calendarFetchStatus).toBe('ready')
+    expect(state.calendarFetchedAt).toBeGreaterThan(0)
+  })
+
+  it('setCalendarEvents with empty array sets status to ready', () => {
+    useShowStore.getState().setCalendarEvents([])
+
+    const state = useShowStore.getState()
+    expect(state.calendarEvents).toEqual([])
+    expect(state.calendarFetchStatus).toBe('ready')
+  })
+
+  it('setCalendarFetchStatus updates status', () => {
+    useShowStore.getState().setCalendarFetchStatus('fetching')
+    expect(useShowStore.getState().calendarFetchStatus).toBe('fetching')
+
+    useShowStore.getState().setCalendarFetchStatus('unavailable')
+    expect(useShowStore.getState().calendarFetchStatus).toBe('unavailable')
+  })
+
+  it('clearCalendarCache resets all calendar state', () => {
+    useShowStore.getState().setCalendarEvents([
+      { title: 'Meeting', start: '10:00', end: '11:00', allDay: false },
+    ])
+
+    useShowStore.getState().clearCalendarCache()
+
+    const state = useShowStore.getState()
+    expect(state.calendarEvents).toEqual([])
+    expect(state.calendarFetchStatus).toBe('idle')
+    expect(state.calendarFetchedAt).toBeNull()
+  })
+
+  it('resetShow clears calendar state', () => {
+    useShowStore.getState().setCalendarEvents([
+      { title: 'Meeting', start: '10:00', end: '11:00', allDay: false },
+    ])
+    useShowStore.getState().setCalendarFetchStatus('ready')
+
+    useShowStore.getState().resetShow()
+
+    const state = useShowStore.getState()
+    expect(state.calendarEvents).toEqual([])
+    expect(state.calendarFetchStatus).toBe('idle')
+    expect(state.calendarFetchedAt).toBeNull()
+  })
+})

--- a/src/renderer/components/CalendarToggle.tsx
+++ b/src/renderer/components/CalendarToggle.tsx
@@ -1,41 +1,79 @@
 import { motion } from 'framer-motion'
+import type { CalendarFetchStatus } from '../../shared/types'
 
 const springTransition = { type: 'spring' as const, stiffness: 300, damping: 30 }
 
 interface CalendarToggleProps {
   checked: boolean
   onChange: (enabled: boolean) => void
+  fetchStatus?: CalendarFetchStatus
+  eventCount?: number
   disabled?: boolean
 }
 
-export function CalendarToggle({ checked, onChange, disabled = false }: CalendarToggleProps) {
+function StatusLabel({ fetchStatus, eventCount }: { fetchStatus: CalendarFetchStatus; eventCount: number }) {
+  switch (fetchStatus) {
+    case 'fetching':
+      return (
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-3 h-3 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+          <span>Checking calendar...</span>
+        </span>
+      )
+    case 'ready':
+      return (
+        <span>
+          {eventCount > 0
+            ? `${eventCount} event${eventCount !== 1 ? 's' : ''} today`
+            : 'No events today'}
+        </span>
+      )
+    case 'unavailable':
+      return <span>Calendar not available</span>
+    case 'error':
+      return <span>Couldn&apos;t reach calendar</span>
+    default:
+      return <span>Import today&apos;s calendar events</span>
+  }
+}
+
+export function CalendarToggle({ checked, onChange, fetchStatus = 'idle', eventCount = 0, disabled = false }: CalendarToggleProps) {
+  const isDisabled = disabled || fetchStatus === 'unavailable' || fetchStatus === 'error'
+
   return (
     <motion.label
       initial={{ opacity: 0, y: -4 }}
       animate={{ opacity: 1, y: 0 }}
       transition={springTransition}
       className={`flex items-center gap-2 mb-4 cursor-pointer select-none ${
-        disabled ? 'opacity-50 cursor-not-allowed' : ''
+        isDisabled ? 'opacity-50 cursor-not-allowed' : ''
       }`}
       data-testid="calendar-toggle"
+      title={
+        fetchStatus === 'unavailable'
+          ? 'Calendar access not available in this Claude session'
+          : fetchStatus === 'error'
+            ? 'Could not connect to calendar'
+            : undefined
+      }
     >
       <input
         type="checkbox"
         checked={checked}
         onChange={(e) => {
-          if (!disabled) onChange(e.target.checked)
+          if (!isDisabled) onChange(e.target.checked)
         }}
-        disabled={disabled}
+        disabled={isDisabled}
         className="sr-only"
       />
       <span
         className={`flex items-center justify-center w-4 h-4 rounded border transition-colors ${
-          checked
+          checked && !isDisabled
             ? 'bg-accent border-accent text-white'
             : 'bg-transparent border-txt-muted'
         }`}
       >
-        {checked && (
+        {checked && !isDisabled && (
           <svg
             className="w-3 h-3"
             viewBox="0 0 12 12"
@@ -49,8 +87,8 @@ export function CalendarToggle({ checked, onChange, disabled = false }: Calendar
           </svg>
         )}
       </span>
-      <span className="text-sm font-body text-txt-secondary">
-        Import today&apos;s calendar events
+      <span className="text-sm font-body text-txt-secondary" data-testid="calendar-status">
+        <StatusLabel fetchStatus={fetchStatus} eventCount={eventCount} />
       </span>
     </motion.label>
   )

--- a/src/renderer/lib/calendar-parser.ts
+++ b/src/renderer/lib/calendar-parser.ts
@@ -1,0 +1,37 @@
+import type { CalendarEvent } from '../../shared/types'
+
+function isCalendarEvent(obj: unknown): obj is CalendarEvent {
+  if (!obj || typeof obj !== 'object') return false
+  const o = obj as Record<string, unknown>
+  return typeof o.title === 'string' && typeof o.start === 'string' && typeof o.end === 'string'
+}
+
+/**
+ * Parse calendar events from Claude's response text.
+ * Expects a JSON array of CalendarEvent objects, optionally wrapped in markdown fences.
+ */
+export function tryParseCalendarEvents(text: string): CalendarEvent[] | null {
+  // Try fenced JSON blocks first
+  const fenced = text.match(/```(?:json)?\s*\n([\s\S]*?)```/)
+  if (fenced) {
+    try {
+      const parsed = JSON.parse(fenced[1])
+      if (Array.isArray(parsed) && (parsed.length === 0 || parsed.every(isCalendarEvent))) {
+        return parsed
+      }
+    } catch {}
+  }
+
+  // Try bare JSON array
+  const bareArray = text.match(/\[[\s\S]*\]/)
+  if (bareArray) {
+    try {
+      const parsed = JSON.parse(bareArray[0])
+      if (Array.isArray(parsed) && (parsed.length === 0 || parsed.every(isCalendarEvent))) {
+        return parsed
+      }
+    } catch {}
+  }
+
+  return null
+}

--- a/src/renderer/stores/showStore.ts
+++ b/src/renderer/stores/showStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { ShowPhase, EnergyLevel, Act, ActStatus, ShowVerdict, ShowLineup, WritersRoomStep, ViewTier } from '../../shared/types'
+import type { ShowPhase, EnergyLevel, Act, ActStatus, ShowVerdict, ShowLineup, WritersRoomStep, ViewTier, CalendarEvent, CalendarFetchStatus } from '../../shared/types'
 import { nextViewTier, expandTier, collapseTier } from '../../shared/types'
 
 function today(): string {
@@ -79,8 +79,14 @@ interface ShowActions {
   // Calendar
   calendarAvailable: boolean
   calendarEnabled: boolean
+  calendarEvents: CalendarEvent[]
+  calendarFetchStatus: CalendarFetchStatus
+  calendarFetchedAt: number | null
   setCalendarAvailable: (available: boolean) => void
   setCalendarEnabled: (enabled: boolean) => void
+  setCalendarEvents: (events: CalendarEvent[]) => void
+  setCalendarFetchStatus: (status: CalendarFetchStatus) => void
+  clearCalendarCache: () => void
 
   // Session
   setClaudeSessionId: (id: string) => void
@@ -112,6 +118,9 @@ interface ShowStoreState {
   breathingPauseEndAt: number | null
   calendarAvailable: boolean
   calendarEnabled: boolean
+  calendarEvents: CalendarEvent[]
+  calendarFetchStatus: CalendarFetchStatus
+  calendarFetchedAt: number | null
 }
 
 export type ShowStore = ShowStoreState & ShowActions
@@ -142,6 +151,9 @@ const initialState: ShowStoreState = {
   breathingPauseEndAt: null,
   calendarAvailable: typeof localStorage !== 'undefined' && localStorage.getItem('showtime-gcal-connected') === 'true',
   calendarEnabled: typeof localStorage !== 'undefined' && localStorage.getItem('showtime-calendar-enabled') === 'true',
+  calendarEvents: [],
+  calendarFetchStatus: 'idle',
+  calendarFetchedAt: null,
 }
 
 // ─── SQLite sync helpers ───
@@ -661,6 +673,20 @@ export const useShowStore = create<ShowStore>()(
         set({ calendarEnabled: enabled })
       },
 
+      setCalendarEvents: (events) => set({
+        calendarEvents: events,
+        calendarFetchStatus: events.length > 0 ? 'ready' : 'ready',
+        calendarFetchedAt: Date.now(),
+      }),
+
+      setCalendarFetchStatus: (status) => set({ calendarFetchStatus: status }),
+
+      clearCalendarCache: () => set({
+        calendarEvents: [],
+        calendarFetchStatus: 'idle',
+        calendarFetchedAt: null,
+      }),
+
       // ─── Session ───
 
       setClaudeSessionId: (id) => set({ claudeSessionId: id }),
@@ -710,7 +736,7 @@ export const useShowStore = create<ShowStore>()(
       name: 'showtime-show-state',
       partialize: (state) => {
         // Don't persist transient UI state
-        const { beatCheckPending: _bcp, celebrationActive: _ca, coldOpenActive: _coa, goingLiveActive: _gla, calendarAvailable: _calA, calendarEnabled: _calE, ...rest } = state
+        const { beatCheckPending: _bcp, celebrationActive: _ca, coldOpenActive: _coa, goingLiveActive: _gla, calendarAvailable: _calA, calendarEnabled: _calE, calendarEvents: _calEvt, calendarFetchStatus: _calFs, calendarFetchedAt: _calFa, ...rest } = state
         return rest
       },
       onRehydrateStorage: () => {

--- a/src/renderer/views/WritersRoomView.tsx
+++ b/src/renderer/views/WritersRoomView.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useShowStore } from '../stores/showStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { tryParseLineup } from '../lib/lineup-parser'
+import { tryParseCalendarEvents } from '../lib/calendar-parser'
 import { EnergySelector } from '../components/EnergySelector'
 import { CalendarBanner } from '../components/CalendarBanner'
 import { CalendarToggle } from '../components/CalendarToggle'
@@ -25,6 +26,10 @@ export function WritersRoomView() {
   const calendarAvailable = useShowStore((s) => s.calendarAvailable)
   const calendarEnabled = useShowStore((s) => s.calendarEnabled)
   const setCalendarEnabled = useShowStore((s) => s.setCalendarEnabled)
+  const calendarEvents = useShowStore((s) => s.calendarEvents)
+  const calendarFetchStatus = useShowStore((s) => s.calendarFetchStatus)
+  const setCalendarEvents = useShowStore((s) => s.setCalendarEvents)
+  const setCalendarFetchStatus = useShowStore((s) => s.setCalendarFetchStatus)
 
   const sendMessage = useSessionStore((s) => s.sendMessage)
   const tabs = useSessionStore((s) => s.tabs)
@@ -38,6 +43,7 @@ export function WritersRoomView() {
   const lineupStartRef = useRef<number | null>(null)
   const [refinementConversations, setRefinementConversations] = useState<Array<{ role: 'user' | 'writer'; text: string }>>([])
   const [isRefining, setIsRefining] = useState(false)
+  const calendarFetchMsgCountRef = useRef<number | null>(null)
 
   // 20-minute nudge timer
   useEffect(() => {
@@ -55,24 +61,76 @@ export function WritersRoomView() {
     return () => clearInterval(interval)
   }, [writersRoomEnteredAt])
 
+  // ─── Calendar Prefetch ───
+  // Trigger calendar fetch when Writer's Room opens and calendar is available
+  useEffect(() => {
+    if (!calendarAvailable || calendarFetchStatus !== 'idle') return
+
+    // Record current message count to identify the calendar response later
+    const tab = tabs.find((t) => t.id === activeTabId)
+    if (!tab) return
+
+    calendarFetchMsgCountRef.current = tab.messages.length
+    setCalendarFetchStatus('fetching')
+
+    const prompt = `List all of today's Google Calendar events as a JSON array.
+Each event: {"title": "...", "start": "HH:MM", "end": "HH:MM", "allDay": false}.
+If no calendar access or no events, return: []
+Return ONLY the JSON array, nothing else.`
+
+    sendMessage(prompt)
+  }, [calendarAvailable, calendarFetchStatus, tabs, activeTabId, sendMessage, setCalendarFetchStatus])
+
+  // Watch for calendar prefetch response
+  useEffect(() => {
+    if (calendarFetchStatus !== 'fetching') return
+    if (calendarFetchMsgCountRef.current === null) return
+
+    const tab = tabs.find((t) => t.id === activeTabId)
+    if (!tab) return
+
+    // Look for assistant messages that appeared after the calendar fetch was sent
+    const newMessages = tab.messages.slice(calendarFetchMsgCountRef.current)
+    const assistantMsg = newMessages.find((m) => m.role === 'assistant' && !m.toolName)
+
+    if (assistantMsg) {
+      const events = tryParseCalendarEvents(assistantMsg.content)
+      if (events !== null) {
+        setCalendarEvents(events)
+        calendarFetchMsgCountRef.current = null
+        return
+      }
+    }
+
+    // Handle completion without valid response
+    if (tab.status === 'completed' || tab.status === 'idle') {
+      const hasNewAssistant = newMessages.some((m) => m.role === 'assistant' && !m.toolName)
+      if (hasNewAssistant) {
+        // Response came but wasn't valid calendar JSON — mark unavailable
+        setCalendarFetchStatus('unavailable')
+        calendarFetchMsgCountRef.current = null
+      }
+    }
+
+    if (tab.status === 'failed' || tab.status === 'dead') {
+      setCalendarFetchStatus('error')
+      calendarFetchMsgCountRef.current = null
+    }
+  }, [tabs, activeTabId, calendarFetchStatus, setCalendarEvents, setCalendarFetchStatus])
+
   const handleBuildLineup = (overrideCalendar?: boolean) => {
     if (!planText.trim()) return
     setIsSubmitting(true)
     setError(null)
 
     const useCalendar = overrideCalendar ?? calendarEnabled
-    const calendarInstruction = useCalendar && calendarAvailable
-      ? `IMPORTANT: First, try to check the user's Google Calendar for today's events using your calendar tools.
-If the calendar tool is unavailable, fails, or returns an error:
-- DO NOT mention the failure to the user
-- Generate the lineup from the user's text input only
-- This is normal — not all setups have calendar access
-
-If calendar events are found: incorporate them as acts in the lineup.
-For calendar events: use event title as act name, event duration as planned duration.
+    const calendarInstruction = useCalendar && calendarEvents.length > 0
+      ? `Here are today's calendar events (already fetched):
+${JSON.stringify(calendarEvents, null, 2)}
+Incorporate these as acts in the lineup. Use event title as act name, event duration for planned duration.
 Categorize: meetings/1:1s → "Admin", focus blocks → "Deep Work", gym → "Exercise", creative → "Creative", social → "Social".
 Add "(from calendar)" to the sketch field for calendar-sourced acts.
-Fill gaps with tasks appropriate for the energy level.
+Fill remaining time with tasks from the user's text input.
 
 `
       : ''
@@ -129,11 +187,7 @@ ${planText}`
     // Check for errors/completion without valid lineup
     if (tab.status === 'failed' || tab.status === 'dead') {
       setIsSubmitting(false)
-      if (calendarEnabled && calendarAvailable) {
-        setError('Lineup generation failed. Try unchecking "Import calendar events" and trying again.')
-      } else {
-        setError('Claude couldn\'t generate a lineup. Try again?')
-      }
+      setError('Claude couldn\'t generate a lineup. Try again?')
       return
     }
 
@@ -142,19 +196,15 @@ ${planText}`
       const hasAssistantMessage = messages.some((m) => m.role === 'assistant' && !m.toolName)
       if (hasAssistantMessage) {
         setIsSubmitting(false)
-        if (calendarEnabled && calendarAvailable) {
-          setError('Lineup generation failed. Try unchecking "Import calendar events" and trying again.')
-        } else {
-          setError('Claude couldn\'t generate a lineup. Try again?')
-        }
+        setError('Claude couldn\'t generate a lineup. Try again?')
       }
     }
-  }, [tabs, activeTabId, isSubmitting, setLineup, setWritersRoomStep, calendarEnabled, calendarAvailable])
+  }, [tabs, activeTabId, isSubmitting, setLineup, setWritersRoomStep])
 
   // Loading phase progression: initial → extended → timeout
-  // Calendar tool calls add 3-10s, so extend timeout when calendar is enabled
-  const timeoutMs = calendarEnabled && calendarAvailable ? 60000 : 30000
-  const extendedMs = calendarEnabled && calendarAvailable ? 15000 : 10000
+  // Calendar events are pre-fetched, so no extra latency for calendar-enabled lineups
+  const timeoutMs = 30000
+  const extendedMs = 10000
 
   useEffect(() => {
     if (!isSubmitting) {
@@ -166,18 +216,14 @@ ${planText}`
     const timeoutTimer = setTimeout(() => {
       setLoadingPhase('timeout')
       setIsSubmitting(false)
-      if (calendarEnabled && calendarAvailable) {
-        setError('Calendar import took too long. Try without calendar or try again?')
-      } else {
-        setError('The writers need a coffee break. Try again?')
-      }
+      setError('The writers need a coffee break. Try again?')
     }, timeoutMs)
 
     return () => {
       clearTimeout(extendedTimer)
       clearTimeout(timeoutTimer)
     }
-  }, [isSubmitting, timeoutMs, extendedMs, calendarEnabled, calendarAvailable])
+  }, [isSubmitting, timeoutMs, extendedMs])
 
   // ─── Lineup Refinement ───
 
@@ -333,6 +379,8 @@ Keep the same format as before. Only modify what the user asked for.`
                       <CalendarToggle
                         checked={calendarEnabled}
                         onChange={setCalendarEnabled}
+                        fetchStatus={calendarFetchStatus}
+                        eventCount={calendarEvents.length}
                       />
                     )}
 
@@ -350,7 +398,7 @@ Keep the same format as before. Only modify what the user asked for.`
                       variant="accent"
                       className="mt-4"
                       disabled={!planText.trim()}
-                      onClick={handleBuildLineup}
+                      onClick={() => handleBuildLineup()}
                     >
                       Build my lineup
                     </Button>
@@ -359,23 +407,11 @@ Keep the same format as before. Only modify what the user asked for.`
                       <div className="flex flex-wrap items-center gap-2 mt-2">
                         <p className="text-xs text-onair">{error}</p>
                         <button
-                          onClick={handleBuildLineup}
+                          onClick={() => handleBuildLineup()}
                           className="text-xs text-accent hover:text-accent-dark underline"
                         >
                           Try again
                         </button>
-                        {calendarEnabled && calendarAvailable && (
-                          <button
-                            onClick={() => {
-                              setCalendarEnabled(false)
-                              handleBuildLineup(false)
-                            }}
-                            className="text-xs text-accent hover:text-accent-dark underline"
-                            data-testid="retry-without-calendar"
-                          >
-                            Generate without calendar
-                          </button>
-                        )}
                       </div>
                     )}
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -325,6 +325,15 @@ export function collapseTier(current: ViewTier): ViewTier {
   return idx > 0 ? VIEW_TIER_ORDER[idx - 1] : current
 }
 
+export interface CalendarEvent {
+  title: string
+  start: string  // "HH:MM"
+  end: string    // "HH:MM"
+  allDay: boolean
+}
+
+export type CalendarFetchStatus = 'idle' | 'fetching' | 'ready' | 'unavailable' | 'error'
+
 export interface Act {
   id: string
   name: string


### PR DESCRIPTION
## Summary
- Move calendar event fetching from mid-lineup-generation (slow MCP tool calls) to background prefetch when Writer's Room opens
- Events are cached in Zustand and injected directly into the lineup prompt, eliminating 3-10s latency and tool-call fragility
- CalendarToggle now shows real-time fetch status (spinner while fetching, event count when ready, error states)

## Changes
| File | Change |
|------|--------|
| `src/shared/types.ts` | Add `CalendarEvent` type and `CalendarFetchStatus` type |
| `src/renderer/stores/showStore.ts` | Add calendar cache state (events, fetchStatus, fetchedAt) and actions |
| `src/renderer/lib/calendar-parser.ts` | New parser for Claude's calendar JSON responses |
| `src/renderer/views/WritersRoomView.tsx` | Trigger prefetch on mount, inject cached events into lineup prompt, fix TS errors |
| `src/renderer/components/CalendarToggle.tsx` | Show fetch status with spinner, event count, unavailable/error states |
| `src/__tests__/calendarPrefetch.test.ts` | 16 unit tests for parser and store state |
| `e2e/writers-room.test.ts` | 3 E2E tests for calendar toggle/banner display |

## Test plan
- [x] 266 unit tests pass (16 new calendar tests + 250 existing)
- [x] TypeScript compiles clean
- [x] Production build succeeds
- [ ] E2E: Calendar banner shows when MCP not available
- [ ] E2E: Calendar toggle shows status when MCP available
- [ ] E2E: Calendar banner dismisses on click
- [ ] Manual: Verify prefetch triggers on Writer's Room entry with Google Calendar MCP configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar event prefetching in Writers Room with real-time status indicators showing fetch progress, event count, and availability.
  * Implemented dismissible calendar banner and enhanced toggle with dynamic status labels for better user feedback.

* **Tests**
  * Added comprehensive E2E and unit test coverage for calendar parsing, state management, and UI interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->