### PR TITLE
feat: chat-first Writer's Room — unified conversation flow

### DIFF
--- a/e2e/showtime.test.ts
+++ b/e2e/showtime.test.ts
@@ -705,69 +705,54 @@ test.describe('Claude E2E Verification (#6, #13)', () => {
     await expect(buildBtn).toBeVisible({ timeout: 3000 })
     await buildBtn.click()
 
-    // Loading indicator should appear immediately
-    const loadingText = page.getByText('The writers are working...')
-    await expect(loadingText).toBeVisible({ timeout: 2000 }).catch(() => {})
+    // Conversation step appears immediately with typing indicator
+    const writerConvo = page.getByTestId('writer-conversation')
+    await expect(writerConvo).toBeVisible({ timeout: 5000 }).catch(() => {})
 
-    // Wait for either: Act cards in lineup OR error/retry UI (30s timeout matches app timeout)
+    // Wait for either: Act cards in lineup OR conversation error message (30s timeout)
     const actCardSelector = page.locator('.bg-surface-hover\\/50').first()
-    const retryButton = page.getByText('Try again')
+    const retryLink = page.locator('button').filter({ hasText: 'Retry' })
 
     let claudePath: 'lineup' | 'unavailable' = 'unavailable'
 
     try {
-      // Race: wait for either Act cards or retry button
       await Promise.race([
         actCardSelector.waitFor({ state: 'visible', timeout: 35000 }).then(() => { claudePath = 'lineup' }),
-        retryButton.waitFor({ state: 'visible', timeout: 35000 }).then(() => { claudePath = 'unavailable' }),
+        retryLink.first().waitFor({ state: 'visible', timeout: 35000 }).then(() => { claudePath = 'unavailable' }),
       ])
     } catch {
-      // If both timeout, check current state
-      const hasRetry = await retryButton.isVisible().catch(() => false)
+      const hasRetry = await retryLink.first().isVisible().catch(() => false)
       if (hasRetry) claudePath = 'unavailable'
     }
 
     if (claudePath === 'lineup') {
-      // Claude responded — verify Act cards structure
       console.log('Claude path: lineup generated successfully')
 
-      // Count Act cards (they use bg-surface-hover/50 class)
       const actCards = page.locator('.bg-surface-hover\\/50')
       const cardCount = await actCards.count()
-      expect(cardCount).toBeGreaterThanOrEqual(2) // Plan mentions 3 activities
+      expect(cardCount).toBeGreaterThanOrEqual(2)
 
-      // Each card should have a name (non-empty text in font-medium)
       const firstCardName = actCards.first().locator('.font-medium')
       await expect(firstCardName).toBeVisible()
       const nameText = await firstCardName.textContent()
       expect(nameText!.trim().length).toBeGreaterThan(0)
 
-      // Each card should have a duration (Xm pattern)
       const durationText = actCards.first().locator('span.text-xs.text-txt-muted')
       await expect(durationText).toBeVisible()
       const duration = await durationText.textContent()
       expect(duration).toMatch(/\d+m/)
 
-      // Each card should have a ClapperboardBadge (category indicator)
       const badge = actCards.first().locator('.font-mono')
       await expect(badge).toBeVisible()
+
+      // Conversation thread should show writer response
+      const writerMessages = writerConvo.locator('.justify-start')
+      expect(await writerMessages.count()).toBeGreaterThanOrEqual(1)
     } else {
-      // Claude unavailable — verify error/retry UI
-      console.log('Claude path: unavailable, error UI verified')
-
-      // Error message should be visible (uses show-metaphor language)
-      const errorMessage = page.locator('.text-onair').first()
-      const hasError = await errorMessage.isVisible().catch(() => false)
-      if (hasError) {
-        const errorText = await errorMessage.textContent()
-        // Should NOT use generic error language
-        expect(errorText).not.toMatch(/^Error$/i)
-        expect(errorText).not.toMatch(/Something went wrong/i)
-        expect(errorText).not.toMatch(/^Failed$/i)
-      }
-
-      // Retry button should be visible and clickable
-      await expect(retryButton).toBeVisible()
+      // Claude unavailable — errors shown as writer messages in conversation
+      console.log('Claude path: unavailable, conversation shows error')
+      const writerMessages = writerConvo.locator('.justify-start')
+      expect(await writerMessages.count()).toBeGreaterThanOrEqual(1)
     }
 
     await screenshot('claude-e2e-verification')

--- a/e2e/writers-room.test.ts
+++ b/e2e/writers-room.test.ts
@@ -43,12 +43,13 @@ test.describe('7.3 — Writer\'s Room Flow', () => {
     await screenshot(page, '04-plan-filled')
   })
 
-  test('can submit plan and see lineup preview', async ({ mainPage: page }) => {
+  test('can submit plan and see conversation view', async ({ mainPage: page }) => {
     const nextButton = page.getByText('Build my lineup')
     if (await nextButton.isVisible().catch(() => false)) {
       await nextButton.click()
-      const loadingText = page.getByText('The writers are working...')
-      await expect(loadingText).toBeVisible({ timeout: 5000 }).catch(() => {})
+      // Conversation step shows typing indicator instead of loading spinner
+      const writerConvo = page.getByTestId('writer-conversation')
+      await expect(writerConvo).toBeVisible({ timeout: 5000 }).catch(() => {})
       await page.waitForTimeout(5000)
     } else {
       const altButton = page.locator('button').filter({ hasText: /lineup|next|continue/i }).first()
@@ -57,7 +58,7 @@ test.describe('7.3 — Writer\'s Room Flow', () => {
         await page.waitForTimeout(5000)
       }
     }
-    await screenshot(page, '05-lineup-preview')
+    await screenshot(page, '05-conversation-view')
   })
 
   test('can go live', async ({ mainPage: page }) => {
@@ -135,21 +136,22 @@ test.describe('Claude E2E Verification (#6, #13)', () => {
     await expect(buildBtn).toBeVisible({ timeout: 3000 })
     await buildBtn.click()
 
-    const loadingText = page.getByText('The writers are working...')
-    await expect(loadingText).toBeVisible({ timeout: 2000 }).catch(() => {})
+    // Conversation step appears immediately with writer typing indicator
+    const writerConvo = page.getByTestId('writer-conversation')
+    await expect(writerConvo).toBeVisible({ timeout: 5000 }).catch(() => {})
 
     const actCardSelector = page.locator('.bg-surface-hover\\/50').first()
-    const retryButton = page.getByRole('button', { name: 'Try again' })
+    const retryLink = page.getByRole('link', { name: 'Retry' }).or(page.locator('button').filter({ hasText: 'Retry' }))
 
     let claudePath: 'lineup' | 'unavailable' = 'unavailable'
 
     try {
       await Promise.race([
         actCardSelector.waitFor({ state: 'visible', timeout: 35000 }).then(() => { claudePath = 'lineup' }),
-        retryButton.waitFor({ state: 'visible', timeout: 35000 }).then(() => { claudePath = 'unavailable' }),
+        retryLink.first().waitFor({ state: 'visible', timeout: 35000 }).then(() => { claudePath = 'unavailable' }),
       ])
     } catch {
-      const hasRetry = await retryButton.isVisible().catch(() => false)
+      const hasRetry = await retryLink.first().isVisible().catch(() => false)
       if (hasRetry) claudePath = 'unavailable'
     }
 
@@ -171,17 +173,16 @@ test.describe('Claude E2E Verification (#6, #13)', () => {
 
       const badge = actCards.first().locator('.font-mono')
       await expect(badge).toBeVisible()
+
+      // Conversation thread should show writer response
+      const writerMessages = writerConvo.locator('.justify-start')
+      expect(await writerMessages.count()).toBeGreaterThanOrEqual(1)
     } else {
-      console.log('Claude path: unavailable, error UI verified')
-      const errorMessage = page.locator('.text-onair').first()
-      const hasError = await errorMessage.isVisible().catch(() => false)
-      if (hasError) {
-        const errorText = await errorMessage.textContent()
-        expect(errorText).not.toMatch(/^Error$/i)
-        expect(errorText).not.toMatch(/Something went wrong/i)
-        expect(errorText).not.toMatch(/^Failed$/i)
-      }
-      await expect(retryButton).toBeVisible()
+      console.log('Claude path: unavailable, conversation shows error message')
+      // In conversation flow, errors appear as writer messages, not separate error UI
+      const writerMessages = writerConvo.locator('.justify-start')
+      const msgCount = await writerMessages.count()
+      expect(msgCount).toBeGreaterThanOrEqual(1)
     }
 
     await screenshot(page, 'claude-e2e-verification')

--- a/src/__tests__/showStore.test.ts
+++ b/src/__tests__/showStore.test.ts
@@ -718,6 +718,11 @@ describe('showStore', () => {
       useShowStore.getState().setWritersRoomStep('plan')
       expect(useShowStore.getState().writersRoomStep).toBe('plan')
     })
+
+    it('supports conversation step', () => {
+      useShowStore.getState().setWritersRoomStep('conversation')
+      expect(useShowStore.getState().writersRoomStep).toBe('conversation')
+    })
   })
 
   // ─── Cold Open Transition ───

--- a/src/renderer/components/LineupChatInput.tsx
+++ b/src/renderer/components/LineupChatInput.tsx
@@ -11,11 +11,12 @@ interface LineupChatInputProps {
   onSend: (message: string) => void
   disabled: boolean
   conversations: Conversation[]
+  hasLineup?: boolean
 }
 
 const springTransition = { type: 'spring' as const, stiffness: 300, damping: 30 }
 
-export function LineupChatInput({ onSend, disabled, conversations }: LineupChatInputProps) {
+export function LineupChatInput({ onSend, disabled, conversations, hasLineup = true }: LineupChatInputProps) {
   const [text, setText] = useState('')
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -91,7 +92,10 @@ export function LineupChatInput({ onSend, disabled, conversations }: LineupChatI
           onChange={(e) => setText(e.target.value)}
           onKeyDown={handleKeyDown}
           disabled={disabled}
-          placeholder="Tell the writers to change something..."
+          placeholder={hasLineup
+            ? (conversations.length > 1 ? 'Anything else to change?' : 'Tell the writers to change something...')
+            : 'Reply to the writer...'
+          }
           className="flex-1 rounded-lg bg-[#151517] border border-[#242428] px-3 py-2 text-sm text-txt-primary placeholder:text-txt-muted focus:outline-none focus:border-accent/50 disabled:opacity-50"
           data-testid="lineup-chat-input"
         />

--- a/src/renderer/views/WritersRoomView.tsx
+++ b/src/renderer/views/WritersRoomView.tsx
@@ -36,14 +36,15 @@ export function WritersRoomView() {
   const activeTabId = useSessionStore((s) => s.activeTabId)
 
   const [planText, setPlanText] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const [showNudge, setShowNudge] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [loadingPhase, setLoadingPhase] = useState<'initial' | 'extended' | 'timeout'>('initial')
   const lineupStartRef = useRef<number | null>(null)
-  const [refinementConversations, setRefinementConversations] = useState<Array<{ role: 'user' | 'writer'; text: string }>>([])
-  const [isRefining, setIsRefining] = useState(false)
   const calendarFetchMsgCountRef = useRef<number | null>(null)
+
+  // Unified conversation state (replaces separate refinementConversations + loading)
+  const [writerConversations, setWriterConversations] = useState<Array<{ role: 'user' | 'writer'; text: string }>>([])
+  const [isWaiting, setIsWaiting] = useState(false)
+  const hasLineup = acts.length > 0
 
   // 20-minute nudge timer
   useEffect(() => {
@@ -62,11 +63,9 @@ export function WritersRoomView() {
   }, [writersRoomEnteredAt])
 
   // ─── Calendar Prefetch ───
-  // Trigger calendar fetch when Writer's Room opens and calendar is available
   useEffect(() => {
     if (!calendarAvailable || calendarFetchStatus !== 'idle') return
 
-    // Record current message count to identify the calendar response later
     const tab = tabs.find((t) => t.id === activeTabId)
     if (!tab) return
 
@@ -89,7 +88,6 @@ Return ONLY the JSON array, nothing else.`
     const tab = tabs.find((t) => t.id === activeTabId)
     if (!tab) return
 
-    // Look for assistant messages that appeared after the calendar fetch was sent
     const newMessages = tab.messages.slice(calendarFetchMsgCountRef.current)
     const assistantMsg = newMessages.find((m) => m.role === 'assistant' && !m.toolName)
 
@@ -102,11 +100,9 @@ Return ONLY the JSON array, nothing else.`
       }
     }
 
-    // Handle completion without valid response
     if (tab.status === 'completed' || tab.status === 'idle') {
       const hasNewAssistant = newMessages.some((m) => m.role === 'assistant' && !m.toolName)
       if (hasNewAssistant) {
-        // Response came but wasn't valid calendar JSON — mark unavailable
         setCalendarFetchStatus('unavailable')
         calendarFetchMsgCountRef.current = null
       }
@@ -118,9 +114,10 @@ Return ONLY the JSON array, nothing else.`
     }
   }, [tabs, activeTabId, calendarFetchStatus, setCalendarEvents, setCalendarFetchStatus])
 
+  // ─── Build Lineup (first message in conversation) ───
+
   const handleBuildLineup = (overrideCalendar?: boolean) => {
     if (!planText.trim()) return
-    setIsSubmitting(true)
     setError(null)
 
     const useCalendar = overrideCalendar ?? calendarEnabled
@@ -155,13 +152,18 @@ Energy "${energy}" means: low=shorter acts, fewer total. medium=balanced. high=l
 User's plan:
 ${planText}`
 
+    // Add plan text as first user message and transition to conversation
+    setWriterConversations([{ role: 'user', text: planText }])
+    setIsWaiting(true)
     lineupStartRef.current = Date.now()
+    setWritersRoomStep('conversation')
     sendMessage(prompt)
   }
 
-  // Watch for Claude's response with lineup
+  // ─── Watch for Claude's response (both initial and refinement) ───
+
   useEffect(() => {
-    if (!isSubmitting) return
+    if (!isWaiting) return
 
     const tab = tabs.find((t) => t.id === activeTabId)
     if (!tab) return
@@ -177,59 +179,48 @@ ${planText}`
           lineupStartRef.current = null
         }
         setLineup(lineup)
-        setWritersRoomStep('lineup')
-        setIsSubmitting(false)
+        setWriterConversations((prev) => [...prev, { role: 'writer', text: 'Done \u2014 lineup updated.' }])
+        setIsWaiting(false)
         setError(null)
+        return
+      }
+
+      // Claude responded but no lineup — show what Claude said
+      if (tab.status === 'completed' || tab.status === 'idle') {
+        const writerText = lastAssistant.content.slice(0, 300)
+        setWriterConversations((prev) => [...prev, { role: 'writer', text: writerText }])
+        setIsWaiting(false)
+        // No error — user can continue the conversation
         return
       }
     }
 
-    // Check for errors/completion without valid lineup
     if (tab.status === 'failed' || tab.status === 'dead') {
-      setIsSubmitting(false)
-      setError('Claude couldn\'t generate a lineup. Try again?')
-      return
+      setWriterConversations((prev) => [...prev, { role: 'writer', text: 'The writer stepped out. Try again?' }])
+      setIsWaiting(false)
+      setError('subprocess')
     }
+  }, [tabs, activeTabId, isWaiting, setLineup])
 
-    // If completed/idle but no lineup parsed from response, show specific error
-    if (tab.status === 'completed' || tab.status === 'idle') {
-      const hasAssistantMessage = messages.some((m) => m.role === 'assistant' && !m.toolName)
-      if (hasAssistantMessage) {
-        setIsSubmitting(false)
-        setError('Claude couldn\'t generate a lineup. Try again?')
-      }
-    }
-  }, [tabs, activeTabId, isSubmitting, setLineup, setWritersRoomStep])
-
-  // Loading phase progression: initial → extended → timeout
-  // Calendar events are pre-fetched, so no extra latency for calendar-enabled lineups
-  const timeoutMs = 30000
-  const extendedMs = 10000
+  // ─── Conversation timeout ───
 
   useEffect(() => {
-    if (!isSubmitting) {
-      setLoadingPhase('initial')
-      return
-    }
+    if (!isWaiting) return
 
-    const extendedTimer = setTimeout(() => setLoadingPhase('extended'), extendedMs)
     const timeoutTimer = setTimeout(() => {
-      setLoadingPhase('timeout')
-      setIsSubmitting(false)
-      setError('The writers need a coffee break. Try again?')
-    }, timeoutMs)
+      setIsWaiting(false)
+      setWriterConversations((prev) => [...prev, { role: 'writer', text: 'The writers need a coffee break. Try again?' }])
+      setError('timeout')
+    }, 30000)
 
-    return () => {
-      clearTimeout(extendedTimer)
-      clearTimeout(timeoutTimer)
-    }
-  }, [isSubmitting, timeoutMs, extendedMs])
+    return () => clearTimeout(timeoutTimer)
+  }, [isWaiting])
 
-  // ─── Lineup Refinement ───
+  // ─── Refinement (subsequent messages in conversation) ───
 
   const handleRefinement = (message: string) => {
-    setRefinementConversations((prev) => [...prev, { role: 'user', text: message }])
-    setIsRefining(true)
+    setWriterConversations((prev) => [...prev, { role: 'user', text: message }])
+    setIsWaiting(true)
 
     const prompt = `The user wants to change the lineup: "${message}"
 
@@ -238,39 +229,6 @@ Keep the same format as before. Only modify what the user asked for.`
 
     sendMessage(prompt)
   }
-
-  // Watch for refined lineup response
-  useEffect(() => {
-    if (!isRefining) return
-
-    const tab = tabs.find((t) => t.id === activeTabId)
-    if (!tab) return
-
-    const messages = tab.messages
-    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant' && !m.toolName)
-
-    if (lastAssistant) {
-      const lineup = tryParseLineup(lastAssistant.content)
-      if (lineup) {
-        setLineup(lineup)
-        setRefinementConversations((prev) => [...prev, { role: 'writer', text: 'Done \u2014 lineup updated.' }])
-        setIsRefining(false)
-        return
-      }
-
-      // No lineup in response — show as clarification
-      if (tab.status === 'completed' || tab.status === 'idle') {
-        const writerText = lastAssistant.content.slice(0, 200)
-        setRefinementConversations((prev) => [...prev, { role: 'writer', text: writerText }])
-        setIsRefining(false)
-      }
-    }
-
-    if (tab.status === 'failed' || tab.status === 'dead') {
-      setRefinementConversations((prev) => [...prev, { role: 'writer', text: 'Something went wrong. Try again?' }])
-      setIsRefining(false)
-    }
-  }, [tabs, activeTabId, isRefining, setLineup])
 
   return (
     <div
@@ -293,12 +251,12 @@ Keep the same format as before. Only modify what the user asked for.`
           className="text-txt-muted hover:text-onair transition-colors text-sm no-drag"
           title="Quit Showtime"
         >
-          ✕
+          &#10005;
         </button>
       </div>
 
       {/* Content */}
-      <div className="px-8 py-8 flex-1 flex flex-col relative">
+      <div className="px-8 py-8 flex-1 flex flex-col relative overflow-y-auto">
         {/* Spotlight gradient overlay */}
         <div className="absolute inset-0 pointer-events-none spotlight-warm" />
 
@@ -324,7 +282,7 @@ Keep the same format as before. Only modify what the user asked for.`
             </motion.div>
           )}
 
-          {/* Step 2: Plan Dump / Loading Overlay */}
+          {/* Step 2: Plan Dump */}
           {writersRoomStep === 'plan' && (
             <motion.div
               key="plan"
@@ -333,129 +291,174 @@ Keep the same format as before. Only modify what the user asked for.`
               exit={{ opacity: 0, y: -12 }}
               transition={springTransition}
             >
-              <AnimatePresence mode="wait">
-                {isSubmitting ? (
-                  <motion.div
-                    key="loading"
-                    className="flex flex-col items-center justify-center py-20 relative"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={springTransition}
-                  >
-                    {/* Spotlight sweep background */}
-                    <div className="absolute inset-0 spotlight-sweep rounded-lg" />
+              <h2 className="font-body text-xl font-semibold text-txt-primary mb-2">
+                What&apos;s on the schedule?
+              </h2>
+              <p className="text-sm text-txt-muted mb-6">
+                Dump everything. Claude will organize it into {getTemporalShowLabel()} lineup.
+              </p>
 
-                    <p className="font-body text-lg text-txt-secondary mb-4 relative z-10">
-                      {loadingPhase === 'extended'
-                        ? 'Still writing... almost there'
-                        : 'The writers are working...'}
-                    </p>
+              {!calendarAvailable && <CalendarBanner />}
+              {calendarAvailable && (
+                <CalendarToggle
+                  checked={calendarEnabled}
+                  onChange={setCalendarEnabled}
+                  fetchStatus={calendarFetchStatus}
+                  eventCount={calendarEvents.length}
+                />
+              )}
 
-                    {/* Pulsing dots */}
-                    <div className="flex gap-2 relative z-10">
-                      <span className="w-2 h-2 rounded-full bg-accent writers-dot-1" />
-                      <span className="w-2 h-2 rounded-full bg-accent writers-dot-2" />
-                      <span className="w-2 h-2 rounded-full bg-accent writers-dot-3" />
-                    </div>
-                  </motion.div>
-                ) : (
-                  <motion.div
-                    key="form"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={springTransition}
-                  >
-                    <h2 className="font-body text-xl font-semibold text-txt-primary mb-2">
-                      What&apos;s on the schedule?
-                    </h2>
-                    <p className="text-sm text-txt-muted mb-6">
-                      Dump everything. Claude will organize it into {getTemporalShowLabel()} lineup.
-                    </p>
+              <div className="bg-notepad-bg border border-notepad-border rounded-lg p-4">
+                <textarea
+                  value={planText}
+                  onChange={(e) => setPlanText(e.target.value)}
+                  placeholder="meetings, tasks, errands, whatever..."
+                  className="w-full h-[200px] resize-none bg-transparent font-body text-sm text-notepad-text placeholder:text-txt-muted focus:outline-none"
+                  autoFocus
+                />
+              </div>
 
-                    {!calendarAvailable && <CalendarBanner />}
-                    {calendarAvailable && (
-                      <CalendarToggle
-                        checked={calendarEnabled}
-                        onChange={setCalendarEnabled}
-                        fetchStatus={calendarFetchStatus}
-                        eventCount={calendarEvents.length}
-                      />
-                    )}
+              <Button
+                variant="accent"
+                className="mt-4"
+                disabled={!planText.trim()}
+                onClick={() => handleBuildLineup()}
+              >
+                Build my lineup
+              </Button>
 
-                    <div className="bg-notepad-bg border border-notepad-border rounded-lg p-4">
-                      <textarea
-                        value={planText}
-                        onChange={(e) => setPlanText(e.target.value)}
-                        placeholder="meetings, tasks, errands, whatever..."
-                        className="w-full h-[200px] resize-none bg-transparent font-body text-sm text-notepad-text placeholder:text-txt-muted focus:outline-none"
-                        autoFocus
-                      />
-                    </div>
-
-                    <Button
-                      variant="accent"
-                      className="mt-4"
-                      disabled={!planText.trim()}
-                      onClick={() => handleBuildLineup()}
-                    >
-                      Build my lineup
-                    </Button>
-
-                    {error && (
-                      <div className="flex flex-wrap items-center gap-2 mt-2">
-                        <p className="text-xs text-onair">{error}</p>
-                        <button
-                          onClick={() => handleBuildLineup()}
-                          className="text-xs text-accent hover:text-accent-dark underline"
-                        >
-                          Try again
-                        </button>
-                      </div>
-                    )}
-
-                    {showNudge && (
-                      <p className="text-xs text-txt-muted mt-4 animate-breathe">
-                        Still writing? No rush — the show starts when you&apos;re ready.
-                      </p>
-                    )}
-                  </motion.div>
-                )}
-              </AnimatePresence>
+              {showNudge && (
+                <p className="text-xs text-txt-muted mt-4 animate-breathe">
+                  Still writing? No rush — the show starts when you&apos;re ready.
+                </p>
+              )}
             </motion.div>
           )}
 
-          {/* Step 3: Lineup Preview */}
-          {writersRoomStep === 'lineup' && (
+          {/* Step 3: Conversation (replaces old loading + lineup steps) */}
+          {writersRoomStep === 'conversation' && (
             <motion.div
-              key="lineup"
+              key="conversation"
               initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -12 }}
               transition={springTransition}
+              className="flex flex-col flex-1"
             >
-              <h2 className="font-body text-xl font-semibold text-txt-primary mb-6">
-                {getTemporalShowLabel().replace(/^./, c => c.toUpperCase())} Lineup
-              </h2>
+              {/* Compact header with energy badge */}
+              <div className="flex items-center justify-between mb-4">
+                <div>
+                  <h2 className="font-body text-xl font-semibold text-txt-primary">
+                    {hasLineup
+                      ? `${getTemporalShowLabel().replace(/^./, (c: string) => c.toUpperCase())} Lineup`
+                      : 'Building your lineup...'}
+                  </h2>
+                  {energy && (
+                    <span className="text-xs text-txt-muted font-mono uppercase tracking-wider">
+                      Energy: {energy}
+                      {calendarEnabled && calendarEvents.length > 0 && (
+                        <> &middot; {calendarEvents.length} calendar event{calendarEvents.length !== 1 ? 's' : ''}</>
+                      )}
+                    </span>
+                  )}
+                </div>
+                {hasLineup && (
+                  <span className="font-mono text-xs text-txt-muted">
+                    {acts.length} ACT{acts.length !== 1 ? 'S' : ''}
+                  </span>
+                )}
+              </div>
 
-              <LineupPanel variant="full" />
+              {/* Lineup preview (appears when lineup exists) */}
+              {hasLineup && (
+                <motion.div
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={springTransition}
+                  className={isWaiting ? 'opacity-50' : ''}
+                >
+                  <LineupPanel variant="full" />
+                </motion.div>
+              )}
 
-              {/* Refinement chat */}
+              {/* Conversation thread */}
+              <div className="mt-4 border-t border-surface-hover pt-4 space-y-3" data-testid="writer-conversation">
+                <AnimatePresence initial={false}>
+                  {writerConversations.map((msg, i) => (
+                    <motion.div
+                      key={`conv-${i}-${msg.role}`}
+                      initial={{ opacity: 0, y: 6 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                      className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                    >
+                      <div
+                        className={`px-4 py-2.5 max-w-[85%] text-sm ${
+                          msg.role === 'user'
+                            ? 'bg-accent/10 border border-accent/20 rounded-xl rounded-br-sm text-txt-primary'
+                            : 'bg-txt-secondary/[0.08] border border-txt-secondary/[0.12] rounded-xl rounded-bl-sm text-txt-secondary'
+                        }`}
+                      >
+                        {msg.text}
+                      </div>
+                    </motion.div>
+                  ))}
+                </AnimatePresence>
+
+                {/* Writers typing indicator */}
+                {isWaiting && (
+                  <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    transition={springTransition}
+                    className="flex justify-start"
+                  >
+                    <div className="bg-txt-secondary/[0.08] border border-txt-secondary/[0.12] rounded-xl rounded-bl-sm px-4 py-3 flex items-center gap-1.5">
+                      <span className="text-xs text-txt-secondary mr-1">The writers are revising</span>
+                      <span className="w-1.5 h-1.5 rounded-full bg-accent writers-dot-1" />
+                      <span className="w-1.5 h-1.5 rounded-full bg-accent writers-dot-2" />
+                      <span className="w-1.5 h-1.5 rounded-full bg-accent writers-dot-3" />
+                    </div>
+                  </motion.div>
+                )}
+              </div>
+
+              {/* Chat input for refinement / follow-up */}
               <LineupChatInput
                 onSend={handleRefinement}
-                disabled={isRefining}
-                conversations={refinementConversations}
+                disabled={isWaiting}
+                conversations={writerConversations}
+                hasLineup={hasLineup}
               />
 
-              <Button
-                variant="primary"
-                className="mt-6"
-                disabled={isRefining}
-                onClick={() => triggerGoingLive()}
-              >
-                WE&apos;RE LIVE!
-              </Button>
+              {/* "We're live!" button (only when lineup exists) */}
+              {hasLineup && (
+                <Button
+                  variant="primary"
+                  className="mt-6"
+                  disabled={isWaiting}
+                  onClick={() => triggerGoingLive()}
+                >
+                  WE&apos;RE LIVE!
+                </Button>
+              )}
+
+              {/* Subprocess error — retry option */}
+              {error === 'subprocess' && (
+                <div className="flex items-center gap-2 mt-2">
+                  <button
+                    onClick={() => {
+                      setError(null)
+                      setIsWaiting(true)
+                      lineupStartRef.current = Date.now()
+                      sendMessage(planText)
+                    }}
+                    className="text-xs text-accent hover:text-accent-dark underline"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
             </motion.div>
           )}
         </AnimatePresence>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -300,7 +300,7 @@ export type ShowPhase = 'no_show' | 'writers_room' | 'live' | 'intermission' | '
 export type EnergyLevel = 'high' | 'medium' | 'low' | 'recovery'
 export type ActStatus = 'upcoming' | 'active' | 'completed' | 'skipped'
 export type ShowVerdict = 'DAY_WON' | 'SOLID_SHOW' | 'GOOD_EFFORT' | 'SHOW_CALLED_EARLY'
-export type WritersRoomStep = 'energy' | 'plan' | 'lineup'
+export type WritersRoomStep = 'energy' | 'plan' | 'conversation'
 export type ViewTier = 'micro' | 'compact' | 'dashboard' | 'expanded'
 
 const VIEW_TIER_ORDER: ViewTier[] = ['micro', 'compact', 'dashboard', 'expanded']


### PR DESCRIPTION
## Summary

Replaces the disconnected plan → loading spinner → lineup steps with a single continuous conversation between the user (Head Writer) and Claude (The Writer).

**Before:** User types plan → loading spinner → either lineup preview or generic error. Chat only available after lineup generated.

**After:** User types plan → "Build my lineup" → Claude's response appears as chat bubble → lineup auto-extracts when detected → same chat continues for refinement → "We're live!"

- Plan text becomes the first message in the conversation thread
- Claude's responses visible as writer bubbles (no more hidden behind spinner)
- Lineup preview appears alongside chat when detected in any message
- If Claude asks a question or reports an error, user sees it and can respond
- No more generic "couldn't generate" error messages
- Refinement chat is the same thread, not a separate step

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced loading states with a live conversation view displaying writer interactions during lineup creation.
  * Added context-aware input placeholders that adapt based on current workflow state.

* **UI Improvements**
  * Enhanced retry mechanism for more robust error recovery.
  * Improved error handling and timeout feedback during the writer planning phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->