### PR TITLE
fix: multi-turn lineup refinement re-detects stale messages (#62)

### DIFF
--- a/docs/plans/multi-turn-fix-design.md
+++ b/docs/plans/multi-turn-fix-design.md
@@ -1,0 +1,147 @@
+# Design: Fix Multi-Turn Conversation (Issue #62)
+
+## Problem
+
+Multi-turn lineup refinement is broken. When a user sends a refinement message (turn 2+),
+the response watcher immediately detects the assistant message from the **previous turn**
+and declares "Done — lineup updated" without waiting for the actual response.
+
+### Root Cause
+
+`WritersRoomView.tsx` line 172:
+```ts
+const lastAssistant = [...messages].reverse().find(m => m.role === 'assistant' && !m.toolName)
+```
+
+This searches ALL messages in the tab — it has no concept of "messages from the current turn."
+On turn 2, the previous turn's assistant message is still the last one (Claude hasn't responded yet),
+so it gets re-detected and the same lineup is re-parsed.
+
+### Proof the Pattern Works Elsewhere
+
+The calendar prefetch watcher (same file, line 72-115) already solves this correctly:
+```ts
+calendarFetchMsgCountRef.current = tab.messages.length  // save offset before sending
+// ...
+const newMessages = tab.messages.slice(calendarFetchMsgCountRef.current)  // only new
+const assistantMsg = newMessages.find(m => m.role === 'assistant' && !m.toolName)
+```
+
+## Fix
+
+Apply the same offset-tracking pattern to the main response watcher.
+
+### Changes
+
+#### 1. Add `responseOffsetRef` (WritersRoomView.tsx)
+
+```ts
+const responseOffsetRef = useRef<number | null>(null)
+```
+
+Replaces `lineupStartRef` for response detection (keep `lineupStartRef` for timing metrics only,
+or merge them into a single ref object).
+
+#### 2. Set offset before sending — `handleBuildLineup()`
+
+```ts
+const handleBuildLineup = () => {
+  // ...
+  const tab = tabs.find(t => t.id === activeTabId)
+  responseOffsetRef.current = tab ? tab.messages.length : 0
+  // ... rest unchanged
+  sendMessage(prompt)
+}
+```
+
+#### 3. Set offset before sending — `handleRefinement()`
+
+```ts
+const handleRefinement = (message: string) => {
+  const tab = tabs.find(t => t.id === activeTabId)
+  responseOffsetRef.current = tab ? tab.messages.length : 0
+  // ... rest unchanged
+  sendMessage(prompt)
+}
+```
+
+#### 4. Fix the response watcher effect
+
+Replace the global search with offset-aware search:
+
+```ts
+useEffect(() => {
+  if (!isWaiting) return
+  if (responseOffsetRef.current === null) return
+
+  const tab = tabs.find(t => t.id === activeTabId)
+  if (!tab) return
+
+  // Only look at messages AFTER the prompt was sent
+  const newMessages = tab.messages.slice(responseOffsetRef.current)
+  const lastAssistant = [...newMessages].reverse().find(m => m.role === 'assistant' && !m.toolName)
+
+  if (lastAssistant) {
+    const lineup = tryParseLineup(lastAssistant.content)
+    if (lineup) {
+      if (lineupStartRef.current) {
+        window.clui.recordMetricTiming('claude.lineup_generation', Date.now() - lineupStartRef.current)
+        lineupStartRef.current = null
+      }
+      setLineup(lineup)
+      setWriterConversations(prev => [...prev, { role: 'writer', text: 'Done — lineup updated.' }])
+      setIsWaiting(false)
+      responseOffsetRef.current = null
+      setError(null)
+      return
+    }
+
+    // Claude responded but no lineup — show what Claude said
+    if (tab.status === 'completed' || tab.status === 'idle') {
+      const writerText = lastAssistant.content.slice(0, 300)
+      setWriterConversations(prev => [...prev, { role: 'writer', text: writerText }])
+      setIsWaiting(false)
+      responseOffsetRef.current = null
+      return
+    }
+  }
+
+  if (tab.status === 'failed' || tab.status === 'dead') {
+    setWriterConversations(prev => [...prev, { role: 'writer', text: 'The writer stepped out. Try again?' }])
+    setIsWaiting(false)
+    responseOffsetRef.current = null
+    setError('subprocess')
+  }
+}, [tabs, activeTabId, isWaiting, setLineup])
+```
+
+### Why NOT in sessionStore?
+
+The offset is view-specific state — it tracks which response a particular UI watcher is waiting for.
+Multiple consumers of sessionStore could be watching for different responses (calendar watcher vs
+lineup watcher). Keeping offsets in refs within the consuming component is the right boundary.
+
+### Why NOT a more complex solution?
+
+- No request-ID matching needed: each watcher only has one outstanding request at a time
+- No message deduplication needed: the offset naturally excludes prior turns
+- No changes to sessionStore, IPC, or the main process: purely a renderer-side fix
+- Matches the existing pattern (calendarFetchMsgCountRef) — consistency over novelty
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/renderer/views/WritersRoomView.tsx` | Add `responseOffsetRef`, update `handleBuildLineup`, `handleRefinement`, and response watcher |
+
+## Testing
+
+- **E2E**: Build lineup, send refinement "make act 1 shorter", verify lineup actually updates (not stale re-detection)
+- **E2E**: Build lineup, send refinement, verify conversation shows both exchanges
+- **E2E**: Build lineup, send refinement that doesn't produce lineup JSON, verify Claude's text response appears
+- **E2E**: Verify calendar prefetch still works (regression)
+- **Unit**: `tryParseLineup` with multi-turn response content (already covered)
+
+## Risk
+
+Low. Single-file change. No IPC or store modifications. Pattern proven by calendar prefetch.

--- a/src/renderer/views/WritersRoomView.tsx
+++ b/src/renderer/views/WritersRoomView.tsx
@@ -44,6 +44,7 @@ export function WritersRoomView() {
   // Unified conversation state (replaces separate refinementConversations + loading)
   const [writerConversations, setWriterConversations] = useState<Array<{ role: 'user' | 'writer'; text: string }>>([])
   const [isWaiting, setIsWaiting] = useState(false)
+  const responseOffsetRef = useRef<number | null>(null)
   const hasLineup = acts.length > 0
 
   // 20-minute nudge timer
@@ -120,6 +121,10 @@ Return ONLY the JSON array, nothing else.`
     if (!planText.trim()) return
     setError(null)
 
+    // Track message offset so the response watcher only sees new messages
+    const tab = tabs.find((t) => t.id === activeTabId)
+    responseOffsetRef.current = tab ? tab.messages.length : 0
+
     const useCalendar = overrideCalendar ?? calendarEnabled
     const calendarInstruction = useCalendar && calendarEvents.length > 0
       ? `Here are today's calendar events (already fetched):
@@ -164,12 +169,14 @@ ${planText}`
 
   useEffect(() => {
     if (!isWaiting) return
+    if (responseOffsetRef.current === null) return
 
     const tab = tabs.find((t) => t.id === activeTabId)
     if (!tab) return
 
-    const messages = tab.messages
-    const lastAssistant = [...messages].reverse().find((m) => m.role === 'assistant' && !m.toolName)
+    // Only look at messages AFTER the prompt was sent (prevents stale re-detection on turn 2+)
+    const newMessages = tab.messages.slice(responseOffsetRef.current)
+    const lastAssistant = [...newMessages].reverse().find((m) => m.role === 'assistant' && !m.toolName)
 
     if (lastAssistant) {
       const lineup = tryParseLineup(lastAssistant.content)
@@ -181,6 +188,7 @@ ${planText}`
         setLineup(lineup)
         setWriterConversations((prev) => [...prev, { role: 'writer', text: 'Done \u2014 lineup updated.' }])
         setIsWaiting(false)
+        responseOffsetRef.current = null
         setError(null)
         return
       }
@@ -190,7 +198,7 @@ ${planText}`
         const writerText = lastAssistant.content.slice(0, 300)
         setWriterConversations((prev) => [...prev, { role: 'writer', text: writerText }])
         setIsWaiting(false)
-        // No error — user can continue the conversation
+        responseOffsetRef.current = null
         return
       }
     }
@@ -198,6 +206,7 @@ ${planText}`
     if (tab.status === 'failed' || tab.status === 'dead') {
       setWriterConversations((prev) => [...prev, { role: 'writer', text: 'The writer stepped out. Try again?' }])
       setIsWaiting(false)
+      responseOffsetRef.current = null
       setError('subprocess')
     }
   }, [tabs, activeTabId, isWaiting, setLineup])
@@ -219,6 +228,10 @@ ${planText}`
   // ─── Refinement (subsequent messages in conversation) ───
 
   const handleRefinement = (message: string) => {
+    // Track message offset so the response watcher only sees new messages
+    const tab = tabs.find((t) => t.id === activeTabId)
+    responseOffsetRef.current = tab ? tab.messages.length : 0
+
     setWriterConversations((prev) => [...prev, { role: 'user', text: message }])
     setIsWaiting(true)
 


### PR DESCRIPTION
## Summary

- **Root cause**: The response watcher in WritersRoomView searched ALL tab messages for the last assistant response. On turn 2+ refinements, it immediately re-detected the previous turn's message and declared "Done — lineup updated" without waiting for Claude's actual response.
- **Fix**: Added `responseOffsetRef` to track `tab.messages.length` at send time. The watcher now only searches messages after the offset — same proven pattern the calendar prefetch watcher already uses.
- **Scope**: Single-file change to `src/renderer/views/WritersRoomView.tsx`. No IPC, store, or main process changes.

## Design doc

`docs/plans/multi-turn-fix-design.md` — included in this PR.

## Test plan

- [ ] Build lineup, send refinement "make act 1 shorter", verify lineup actually updates (not stale re-detection)
- [ ] Build lineup, send refinement, verify conversation shows both exchanges
- [ ] Build lineup, send refinement that doesn't produce lineup JSON, verify Claude's text response appears
- [ ] Verify calendar prefetch still works (regression)
- [ ] `npm run test` — 267 unit tests pass

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue in Writers Room where multi-turn lineup refinement would re-detect and re-process the previous turn's assistant response, leading to incorrect handling during iterative refinement operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->