### PR TITLE
fix: refinement prompt includes lineup context, energy, and MCP prohibition (#73)

### DIFF
--- a/src/__tests__/refinementPrompt.test.ts
+++ b/src/__tests__/refinementPrompt.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { buildRefinementPrompt } from '../renderer/lib/refinement-prompt'
+
+const SAMPLE_ACTS = [
+  { name: 'Deep Work Session', sketch: 'Deep Work', durationMinutes: 45 },
+  { name: 'Exercise Break', sketch: 'Exercise', durationMinutes: 25 },
+  { name: 'Email & Slack', sketch: 'Admin', durationMinutes: 20 },
+]
+
+describe('buildRefinementPrompt', () => {
+  it('includes current lineup JSON', () => {
+    const prompt = buildRefinementPrompt('Add a coffee break', 'high', SAMPLE_ACTS)
+    expect(prompt).toContain('"name": "Deep Work Session"')
+    expect(prompt).toContain('"name": "Exercise Break"')
+    expect(prompt).toContain('"name": "Email & Slack"')
+    expect(prompt).toContain('showtime-lineup')
+  })
+
+  it('includes the energy level', () => {
+    const prompt = buildRefinementPrompt('Add a coffee break', 'low', SAMPLE_ACTS)
+    expect(prompt).toContain('energy level "low"')
+  })
+
+  it('includes category constraints', () => {
+    const prompt = buildRefinementPrompt('Add a coffee break', 'high', SAMPLE_ACTS)
+    expect(prompt).toContain('"Deep Work"')
+    expect(prompt).toContain('"Exercise"')
+    expect(prompt).toContain('"Admin"')
+    expect(prompt).toContain('"Creative"')
+    expect(prompt).toContain('"Social"')
+  })
+
+  it('explicitly prohibits MCP tools', () => {
+    const prompt = buildRefinementPrompt('Add dinner date with Silas', 'medium', SAMPLE_ACTS)
+    expect(prompt).toContain('Do NOT use any MCP tools')
+    expect(prompt).toContain('Do NOT call any tools at all')
+  })
+
+  it('includes the user refinement message', () => {
+    const prompt = buildRefinementPrompt('Add dinner date with Silas', 'high', SAMPLE_ACTS)
+    expect(prompt).toContain('Add dinner date with Silas')
+  })
+
+  it('instructs to preserve existing acts', () => {
+    const prompt = buildRefinementPrompt('Add a walk', 'high', SAMPLE_ACTS)
+    expect(prompt).toContain('Preserve all existing acts')
+  })
+
+  it('only includes name, sketch, durationMinutes in lineup JSON (no extra fields)', () => {
+    const actsWithExtras = [
+      { name: 'Test', sketch: 'Admin', durationMinutes: 30, id: 'should-strip', status: 'active' },
+    ] as any
+    const prompt = buildRefinementPrompt('test', 'high', actsWithExtras)
+    expect(prompt).not.toContain('should-strip')
+    expect(prompt).not.toContain('"status"')
+  })
+
+  it('handles empty acts array', () => {
+    const prompt = buildRefinementPrompt('Add something', 'high', [])
+    expect(prompt).toContain('"acts": []')
+    expect(prompt).toContain('energy level "high"')
+  })
+})

--- a/src/renderer/lib/refinement-prompt.ts
+++ b/src/renderer/lib/refinement-prompt.ts
@@ -1,0 +1,34 @@
+/**
+ * Builds the refinement prompt sent to Claude when the user wants to modify an existing lineup.
+ * Includes full context: current lineup JSON, energy level, category constraints, and MCP prohibition.
+ */
+export function buildRefinementPrompt(
+  message: string,
+  energy: string,
+  acts: Array<{ name: string; sketch: string; durationMinutes: number }>,
+): string {
+  const currentLineupJSON = JSON.stringify({
+    acts: acts.map((a) => ({
+      name: a.name,
+      sketch: a.sketch,
+      durationMinutes: a.durationMinutes,
+    })),
+  }, null, 2)
+
+  return `You are Showtime, an ADHD-friendly day planner. The user has energy level "${energy}".
+
+Here is the current show lineup:
+\`\`\`showtime-lineup
+${currentLineupJSON}
+\`\`\`
+
+The user wants to modify the lineup: "${message}"
+
+IMPORTANT:
+- Do NOT use any MCP tools (no Google Calendar, no web search, no file operations)
+- Do NOT call any tools at all — just respond with the updated lineup
+- Respond with the COMPLETE updated lineup as a \`\`\`showtime-lineup JSON block
+- Categories must be one of: "Deep Work", "Exercise", "Admin", "Creative", "Social"
+- Keep the same format. Only modify what the user asked for.
+- Preserve all existing acts unless the user specifically asks to remove them`
+}

--- a/src/renderer/views/WritersRoomView.tsx
+++ b/src/renderer/views/WritersRoomView.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useShowStore } from '../stores/showStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { tryParseLineup } from '../lib/lineup-parser'
+import { buildRefinementPrompt } from '../lib/refinement-prompt'
 import { tryParseCalendarEvents } from '../lib/calendar-parser'
 import { EnergySelector } from '../components/EnergySelector'
 import { CalendarBanner } from '../components/CalendarBanner'
@@ -258,10 +259,7 @@ ${planText}`
     setWriterConversations((prev) => [...prev, { role: 'user', text: message }])
     setIsWaiting(true)
 
-    const prompt = `The user wants to change the lineup: "${message}"
-
-Respond with the complete updated lineup as a showtime-lineup JSON block.
-Keep the same format as before. Only modify what the user asked for.`
+    const prompt = buildRefinementPrompt(message, energy!, acts)
 
     sendMessage(prompt)
   }


### PR DESCRIPTION
## Summary

- **Fixes #73**: Refinement prompt now includes current lineup JSON, energy level, category constraints, and explicit MCP tool prohibition
- Extracted `buildRefinementPrompt()` into a testable pure function (`src/renderer/lib/refinement-prompt.ts`)
- Added 8 unit tests covering all PRD requirements

## What changed

The refinement prompt in `WritersRoomView.tsx` was sending only:
```
The user wants to change the lineup: "{message}"
Respond with the complete updated lineup as a showtime-lineup JSON block.
```

This caused Claude to respond with raw calendar JSON (via MCP tools) instead of updating the lineup. The fix mirrors the initial build prompt structure with full context.

## Test plan

- [x] 8 unit tests for `buildRefinementPrompt()` — all pass
- [x] Full vitest suite: 427/427 non-dataLayer tests pass (27 pre-existing dataLayer failures from better-sqlite3 ABI mismatch)
- [ ] Manual: send "Add dinner date with Silas" → verify NO calendar MCP calls, lineup updates with Social act

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite validating the refinement prompt generation correctly includes current lineup information, energy levels, category constraints, and user-requested modifications while excluding internal act properties.

* **Refactor**
  * Refactored refinement prompt construction from inline implementation into a dedicated, reusable utility function to improve code maintainability and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->