### PR TITLE
feat: Writer's Room hydration + shared SQLite access (#135, #125)

### DIFF
--- a/src/__tests__/dbPath.test.ts
+++ b/src/__tests__/dbPath.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for cross-context DB path resolution.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'path'
+import { homedir } from 'os'
+
+// We test the Node.js fallback path since Electron's app module
+// isn't available in the test environment.
+
+describe('resolveDbPath', () => {
+  let originalPlatform: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    // Clear module cache so we can re-import with different mocks
+    vi.resetModules()
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  })
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('resolves macOS path when not in Electron', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', writable: true })
+    const { resolveDbPath } = await import('../shared/db-path')
+    const result = resolveDbPath()
+    expect(result).toBe(join(homedir(), 'Library', 'Application Support', 'showtime', 'showtime.db'))
+  })
+
+  it('resolves Linux path when not in Electron', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', writable: true })
+    delete process.env.XDG_CONFIG_HOME
+    const { resolveDbPath } = await import('../shared/db-path')
+    const result = resolveDbPath()
+    expect(result).toBe(join(homedir(), '.config', 'showtime', 'showtime.db'))
+  })
+
+  it('resolves Linux path with XDG_CONFIG_HOME', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', writable: true })
+    process.env.XDG_CONFIG_HOME = '/custom/config'
+    const { resolveDbPath } = await import('../shared/db-path')
+    const result = resolveDbPath()
+    expect(result).toBe(join('/custom/config', 'showtime', 'showtime.db'))
+    delete process.env.XDG_CONFIG_HOME
+  })
+
+  it('returns a path ending with showtime.db', async () => {
+    const { resolveDbPath } = await import('../shared/db-path')
+    const result = resolveDbPath()
+    expect(result.endsWith('showtime.db')).toBe(true)
+  })
+
+  it('returns an absolute path', async () => {
+    const { resolveDbPath } = await import('../shared/db-path')
+    const result = resolveDbPath()
+    expect(result.startsWith('/')).toBe(true)
+  })
+})

--- a/src/__tests__/resumeDetection.test.ts
+++ b/src/__tests__/resumeDetection.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for DarkStudioView resume detection (getTodayPersistedShow).
+ * Runs in jsdom environment for localStorage access.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getTodayPersistedShow } from '../renderer/views/DarkStudioView'
+
+describe('getTodayPersistedShow', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('detects today\'s show from localStorage', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    localStorage.setItem('showtime-show-state', JSON.stringify({
+      stateValue: { phase: 'live', animation: 'idle' },
+      context: {
+        showDate: today,
+        acts: [
+          { id: '1', status: 'completed', name: 'Act 1' },
+          { id: '2', status: 'active', name: 'Act 2' },
+          { id: '3', status: 'upcoming', name: 'Act 3' },
+        ],
+        verdict: null,
+      },
+      savedAt: Date.now(),
+    }))
+
+    const result = getTodayPersistedShow()
+    expect(result).not.toBeNull()
+    expect(result!.actCount).toBe(3)
+    expect(result!.completedCount).toBe(1)
+    expect(result!.phase).toBe('live')
+    expect(result!.isStrike).toBe(false)
+  })
+
+  it('returns null for yesterday\'s show', () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10)
+    localStorage.setItem('showtime-show-state', JSON.stringify({
+      stateValue: { phase: 'live', animation: 'idle' },
+      context: {
+        showDate: yesterday,
+        acts: [{ id: '1', status: 'active' }],
+        verdict: null,
+      },
+      savedAt: Date.now() - 86400000,
+    }))
+
+    const result = getTodayPersistedShow()
+    expect(result).toBeNull()
+  })
+
+  it('detects strike phase', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    localStorage.setItem('showtime-show-state', JSON.stringify({
+      stateValue: { phase: 'strike', animation: 'idle' },
+      context: {
+        showDate: today,
+        acts: [
+          { id: '1', status: 'completed' },
+          { id: '2', status: 'completed' },
+        ],
+        verdict: 'DAY_WON',
+      },
+      savedAt: Date.now(),
+    }))
+
+    const result = getTodayPersistedShow()
+    expect(result).not.toBeNull()
+    expect(result!.isStrike).toBe(true)
+    expect(result!.completedCount).toBe(2)
+  })
+
+  it('returns null when no data stored', () => {
+    const result = getTodayPersistedShow()
+    expect(result).toBeNull()
+  })
+
+  it('returns null for corrupt JSON', () => {
+    localStorage.setItem('showtime-show-state', 'not valid json{{{')
+    const result = getTodayPersistedShow()
+    expect(result).toBeNull()
+  })
+
+  it('identifies writers_room phase (acts exist but none active)', () => {
+    const today = new Date().toISOString().slice(0, 10)
+    localStorage.setItem('showtime-show-state', JSON.stringify({
+      stateValue: { phase: 'writers_room', animation: 'idle' },
+      context: {
+        showDate: today,
+        acts: [
+          { id: '1', status: 'upcoming' },
+          { id: '2', status: 'upcoming' },
+        ],
+        verdict: null,
+      },
+      savedAt: Date.now(),
+    }))
+
+    const result = getTodayPersistedShow()
+    expect(result).not.toBeNull()
+    expect(result!.phase).toBe('writers_room')
+    expect(result!.completedCount).toBe(0)
+  })
+})

--- a/src/__tests__/showtimeDb.test.ts
+++ b/src/__tests__/showtimeDb.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+/**
+ * Tests for the shared showtime-db module (readToday, writeLineup, getPhase).
+ *
+ * Uses a real SQLite database in a temp directory with proper migrations.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { join } from 'path'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import Database from 'better-sqlite3'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp/showtime-test', getVersion: () => '0.0.0-test' },
+}))
+
+import { readToday, writeLineup, getPhase, type Lineup } from '../shared/showtime-db'
+
+let tmpDir: string
+let dbPath: string
+
+function setupDb(path: string): void {
+  const db = new Database(path)
+  db.pragma('journal_mode = WAL')
+  db.pragma('foreign_keys = ON')
+
+  // Run migrations manually (same schema as DataService)
+  const migrationsDir = join(__dirname, '..', 'main', 'data', 'migrations')
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const fs = require('fs')
+  const files = fs.readdirSync(migrationsDir).filter((f: string) => f.endsWith('.sql')).sort()
+  for (const file of files) {
+    const sql = fs.readFileSync(join(migrationsDir, file), 'utf-8')
+    db.exec(sql)
+  }
+  db.close()
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'showtime-db-test-'))
+  dbPath = join(tmpDir, 'showtime.db')
+  setupDb(dbPath)
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const sampleLineup: Lineup = {
+  acts: [
+    { name: 'Deep Work: Project', sketch: 'Deep Work', durationMinutes: 60 },
+    { name: 'Gym Session', sketch: 'Exercise', durationMinutes: 45 },
+    { name: 'Email Triage', sketch: 'Admin', durationMinutes: 30 },
+  ],
+  beatThreshold: 3,
+  openingNote: 'Three-act show today. Let\'s go.',
+}
+
+describe('writeLineup + readToday', () => {
+  it('writes a lineup and reads it back', () => {
+    writeLineup(sampleLineup, 'high', dbPath)
+
+    const result = readToday(dbPath)
+    expect(result).not.toBeNull()
+    expect(result!.show.phase).toBe('writers_room')
+    expect(result!.show.energy).toBe('high')
+    expect(result!.show.beatThreshold).toBe(3)
+    expect(result!.show.planText).toBe(sampleLineup.openingNote)
+    expect(result!.acts).toHaveLength(3)
+    expect(result!.acts[0].name).toBe('Deep Work: Project')
+    expect(result!.acts[0].sketch).toBe('Deep Work')
+    expect(result!.acts[0].plannedDurationMs).toBe(60 * 60 * 1000)
+    expect(result!.acts[1].name).toBe('Gym Session')
+    expect(result!.acts[2].name).toBe('Email Triage')
+  })
+
+  it('acts are ordered by sort_order', () => {
+    writeLineup(sampleLineup, 'medium', dbPath)
+
+    const result = readToday(dbPath)
+    for (let i = 0; i < result!.acts.length; i++) {
+      expect(result!.acts[i].sortOrder).toBe(i)
+    }
+  })
+
+  it('replaces existing lineup on re-write', () => {
+    writeLineup(sampleLineup, 'high', dbPath)
+
+    const newLineup: Lineup = {
+      acts: [{ name: 'Solo Act', sketch: 'Creative', durationMinutes: 90 }],
+      beatThreshold: 1,
+    }
+    writeLineup(newLineup, 'low', dbPath)
+
+    const result = readToday(dbPath)
+    expect(result!.acts).toHaveLength(1)
+    expect(result!.acts[0].name).toBe('Solo Act')
+    expect(result!.show.energy).toBe('low')
+    expect(result!.show.beatThreshold).toBe(1)
+  })
+
+  it('writes default energy as null when not provided', () => {
+    writeLineup(sampleLineup, undefined, dbPath)
+
+    const result = readToday(dbPath)
+    expect(result!.show.energy).toBeNull()
+  })
+})
+
+describe('readToday', () => {
+  it('returns null when no show exists', () => {
+    const result = readToday(dbPath)
+    expect(result).toBeNull()
+  })
+
+  it('returns null when DB file does not exist', () => {
+    const result = readToday('/nonexistent/path/showtime.db')
+    expect(result).toBeNull()
+  })
+})
+
+describe('getPhase', () => {
+  it('returns phase of today\'s show', () => {
+    writeLineup(sampleLineup, 'high', dbPath)
+
+    const phase = getPhase(dbPath)
+    expect(phase).toBe('writers_room')
+  })
+
+  it('returns null when no show exists', () => {
+    const phase = getPhase(dbPath)
+    expect(phase).toBeNull()
+  })
+
+  it('returns null when DB file does not exist', () => {
+    const phase = getPhase('/nonexistent/path/showtime.db')
+    expect(phase).toBeNull()
+  })
+
+  it('reflects phase updates', () => {
+    writeLineup(sampleLineup, 'high', dbPath)
+
+    // Manually update phase
+    const db = new Database(dbPath)
+    const today = new Date().toISOString().slice(0, 10)
+    db.prepare('UPDATE shows SET phase = ? WHERE id = ?').run('live', today)
+    db.close()
+
+    const phase = getPhase(dbPath)
+    expect(phase).toBe('live')
+  })
+})
+
+// DarkStudioView resume detection tests are in resumeDetection.test.ts
+// (requires jsdom environment for localStorage)

--- a/src/__tests__/timeOfDay.test.ts
+++ b/src/__tests__/timeOfDay.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for time-of-day prompt logic and quick-start templates.
+ */
+import { describe, it, expect } from 'vitest'
+import { getTimeOfDayPrompt, getQuickStartTemplates } from '../renderer/views/WritersRoomView'
+
+describe('getTimeOfDayPrompt', () => {
+  it('returns morning prompt before 10am', () => {
+    const result = getTimeOfDayPrompt(8)
+    expect(result.period).toBe('morning')
+    expect(result.greeting).toContain('Fresh start')
+  })
+
+  it('returns morning prompt at 0 (midnight)', () => {
+    const result = getTimeOfDayPrompt(0)
+    expect(result.period).toBe('morning')
+  })
+
+  it('returns morning prompt at 9', () => {
+    const result = getTimeOfDayPrompt(9)
+    expect(result.period).toBe('morning')
+  })
+
+  it('returns midday prompt at 10am', () => {
+    const result = getTimeOfDayPrompt(10)
+    expect(result.period).toBe('midday')
+    expect(result.greeting).toContain('Afternoon')
+  })
+
+  it('returns midday prompt at 13 (1pm)', () => {
+    const result = getTimeOfDayPrompt(13)
+    expect(result.period).toBe('midday')
+  })
+
+  it('returns late prompt at 14 (2pm)', () => {
+    const result = getTimeOfDayPrompt(14)
+    expect(result.period).toBe('late')
+    expect(result.greeting).toContain('wind-down')
+  })
+
+  it('returns late prompt at 17 (5pm)', () => {
+    const result = getTimeOfDayPrompt(17)
+    expect(result.period).toBe('late')
+  })
+
+  it('returns evening prompt at 18 (6pm)', () => {
+    const result = getTimeOfDayPrompt(18)
+    expect(result.period).toBe('evening')
+    expect(result.greeting).toContain('wrapping up')
+  })
+
+  it('returns evening prompt at 23 (11pm)', () => {
+    const result = getTimeOfDayPrompt(23)
+    expect(result.period).toBe('evening')
+  })
+
+  it('always returns greeting and sub fields', () => {
+    for (let h = 0; h < 24; h++) {
+      const result = getTimeOfDayPrompt(h)
+      expect(result.greeting).toBeTruthy()
+      expect(result.sub).toBeTruthy()
+      expect(['morning', 'midday', 'late', 'evening']).toContain(result.period)
+    }
+  })
+})
+
+describe('getQuickStartTemplates', () => {
+  it('returns all 4 templates', () => {
+    const templates = getQuickStartTemplates({ hasTodayShow: false, hasYesterdayLineup: false })
+    expect(templates).toHaveLength(4)
+  })
+
+  it('resume template is available when hasTodayShow is true', () => {
+    const templates = getQuickStartTemplates({ hasTodayShow: true, hasYesterdayLineup: false })
+    const resume = templates.find(t => t.id === 'resume')
+    expect(resume?.available).toBe(true)
+  })
+
+  it('resume template is unavailable when no today show', () => {
+    const templates = getQuickStartTemplates({ hasTodayShow: false, hasYesterdayLineup: false })
+    const resume = templates.find(t => t.id === 'resume')
+    expect(resume?.available).toBe(false)
+  })
+
+  it('yesterday template is available when hasYesterdayLineup is true', () => {
+    const templates = getQuickStartTemplates({ hasTodayShow: false, hasYesterdayLineup: true })
+    const yesterday = templates.find(t => t.id === 'yesterday')
+    expect(yesterday?.available).toBe(true)
+  })
+
+  it('light and deep-focus are always available', () => {
+    const templates = getQuickStartTemplates({ hasTodayShow: false, hasYesterdayLineup: false })
+    expect(templates.find(t => t.id === 'light')?.available).toBe(true)
+    expect(templates.find(t => t.id === 'deep-focus')?.available).toBe(true)
+  })
+
+  it('each template has id, label, description', () => {
+    const templates = getQuickStartTemplates({ hasTodayShow: true, hasYesterdayLineup: true })
+    for (const t of templates) {
+      expect(t.id).toBeTruthy()
+      expect(t.label).toBeTruthy()
+      expect(t.description).toBeTruthy()
+    }
+  })
+})

--- a/src/renderer/views/DarkStudioView.tsx
+++ b/src/renderer/views/DarkStudioView.tsx
@@ -3,8 +3,53 @@ import { motion } from 'framer-motion'
 import { useShowSend } from '../machines/ShowMachineProvider'
 import { Button } from '../ui/button'
 
-function getTemporalGreeting(): { heading: string; sub: string } {
+const PERSIST_KEY = 'showtime-show-state'
+
+interface PersistedShowInfo {
+  phase: string
+  actCount: number
+  completedCount: number
+  isStrike: boolean
+}
+
+/** Check localStorage for today's persisted show state */
+export function getTodayPersistedShow(): PersistedShowInfo | null {
+  try {
+    const raw = localStorage.getItem(PERSIST_KEY)
+    if (!raw) return null
+    const { context } = JSON.parse(raw)
+    if (!context) return null
+    const today = new Date().toISOString().slice(0, 10)
+    if (context.showDate !== today) return null
+
+    const acts = context.acts ?? []
+    const completedCount = acts.filter((a: { status: string }) =>
+      a.status === 'completed'
+    ).length
+
+    // Determine phase from the persisted state
+    const phase = context.verdict ? 'strike' : (acts.some((a: { status: string }) => a.status === 'active') ? 'live' : 'writers_room')
+
+    return {
+      phase,
+      actCount: acts.length,
+      completedCount,
+      isStrike: !!context.verdict,
+    }
+  } catch {
+    return null
+  }
+}
+
+function getTemporalGreeting(hasShow: boolean): { heading: string; sub: string } {
   const hour = new Date().getHours()
+
+  if (hasShow) {
+    if (hour < 12) return { heading: "Your show is waiting.", sub: 'Pick up where you left off.' }
+    if (hour < 18) return { heading: "The show must go on.", sub: 'Resume your lineup and keep the momentum.' }
+    return { heading: "Tonight's show has a history.", sub: 'Review or wrap up.' }
+  }
+
   if (hour < 12) {
     return {
       heading: "Today's show hasn't been written yet.",
@@ -30,12 +75,20 @@ interface DarkStudioViewProps {
 export function DarkStudioView({ onShowHistory }: DarkStudioViewProps) {
   const send = useShowSend()
   const triggerColdOpen = useCallback(() => send({ type: 'TRIGGER_COLD_OPEN' }), [send])
-  const greeting = useMemo(getTemporalGreeting, [])
+  const todayShow = useMemo(getTodayPersistedShow, [])
+  const greeting = useMemo(() => getTemporalGreeting(!!todayShow), [todayShow])
 
   // Pre-warm Claude subprocess for faster Writer's Room startup
   useEffect(() => {
     window.clui.prewarmSubprocess()
   }, [])
+
+  const handleResumeShow = useCallback(() => {
+    // ENTER_WRITERS_ROOM will hydrate from localStorage (showActor already does this)
+    // The persisted snapshot is already loaded by showActor on app start
+    // Just trigger the cold open which transitions to writers_room
+    send({ type: 'TRIGGER_COLD_OPEN' })
+  }, [send])
 
   return (
     <div
@@ -59,15 +112,47 @@ export function DarkStudioView({ onShowHistory }: DarkStudioViewProps) {
           {greeting.sub}
         </p>
 
+        {/* Show summary when resuming */}
+        {todayShow && !todayShow.isStrike && (
+          <motion.p
+            className="font-mono text-xs text-txt-secondary mt-2"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ type: 'spring', stiffness: 200, damping: 25, delay: 0.6 }}
+            data-testid="resume-summary"
+          >
+            {todayShow.completedCount}/{todayShow.actCount} acts done
+            {todayShow.phase === 'live' && ' — show in progress'}
+          </motion.p>
+        )}
+
+        {todayShow && todayShow.isStrike && (
+          <motion.p
+            className="font-mono text-xs text-beat mt-2"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ type: 'spring', stiffness: 200, damping: 25, delay: 0.6 }}
+            data-testid="strike-summary"
+          >
+            Show complete — {todayShow.completedCount} acts wrapped
+          </motion.p>
+        )}
+
         <motion.div
           className="mt-8 flex items-center gap-3"
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ type: 'spring', stiffness: 200, damping: 25, delay: 1.2 }}
         >
-          <Button variant="accent" onClick={triggerColdOpen} data-testid="enter-writers-room">
-            Enter the Writer&apos;s Room
-          </Button>
+          {todayShow && !todayShow.isStrike ? (
+            <Button variant="accent" onClick={handleResumeShow} data-testid="resume-show-btn">
+              Resume Today&apos;s Show
+            </Button>
+          ) : (
+            <Button variant="accent" onClick={triggerColdOpen} data-testid="enter-writers-room">
+              Enter the Writer&apos;s Room
+            </Button>
+          )}
           {onShowHistory && (
             <Button variant="ghost_muted" onClick={onShowHistory}>
               Past Shows

--- a/src/renderer/views/WritersRoomView.tsx
+++ b/src/renderer/views/WritersRoomView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useShowContext, useShowSend } from '../machines/ShowMachineProvider'
 import { useUIStore } from '../stores/uiStore'
 import { useSessionStore } from '../stores/sessionStore'
@@ -16,6 +16,69 @@ import { cn } from '../lib/utils'
 import type { EnergyLevel, ShowLineup } from '../../shared/types'
 
 const springTransition = { type: 'spring' as const, stiffness: 300, damping: 30 }
+
+// ─── Time-of-day contextual prompts ───
+
+export interface TimeOfDayPrompt {
+  greeting: string
+  sub: string
+  period: 'morning' | 'midday' | 'late' | 'evening'
+}
+
+export function getTimeOfDayPrompt(hour?: number): TimeOfDayPrompt {
+  const h = hour ?? new Date().getHours()
+  if (h < 10) {
+    return { greeting: "Fresh start! Let's build today's show.", sub: 'The morning is prime time.', period: 'morning' }
+  }
+  if (h < 14) {
+    return { greeting: "Afternoon \u2014 here's what's left.", sub: 'Midday momentum.', period: 'midday' }
+  }
+  if (h < 18) {
+    return { greeting: 'Evening wind-down.', sub: 'Focus on what matters most.', period: 'late' }
+  }
+  return { greeting: "Show's wrapping up.", sub: 'Strike or encore?', period: 'evening' }
+}
+
+// ─── Quick-start template definitions ───
+
+export interface QuickStartTemplate {
+  id: string
+  label: string
+  description: string
+  available: boolean
+}
+
+export function getQuickStartTemplates(opts: {
+  hasTodayShow: boolean
+  hasYesterdayLineup: boolean
+}): QuickStartTemplate[] {
+  return [
+    {
+      id: 'resume',
+      label: "Resume today's show",
+      description: 'Pick up where you left off',
+      available: opts.hasTodayShow,
+    },
+    {
+      id: 'yesterday',
+      label: 'Same lineup as yesterday',
+      description: 'Repeat what worked',
+      available: opts.hasYesterdayLineup,
+    },
+    {
+      id: 'light',
+      label: 'Light day',
+      description: '2\u20133 gentle acts, low pressure',
+      available: true,
+    },
+    {
+      id: 'deep-focus',
+      label: 'Deep focus day',
+      description: 'Long deep work blocks, minimal switching',
+      available: true,
+    },
+  ]
+}
 
 const ENERGY_OPTIONS: { level: EnergyLevel; emoji: string; label: string }[] = [
   { level: 'high', emoji: '⚡', label: 'High' },
@@ -56,6 +119,7 @@ export function WritersRoomView() {
   const messages = tab?.messages ?? []
   const isRunning = tab?.status === 'running' || tab?.status === 'connecting'
   const currentActivity = tab?.currentActivity ?? ''
+  const timePrompt = useMemo(() => getTimeOfDayPrompt(), [])
 
   // Auto-scroll: scroll to bottom when near bottom (<60px threshold)
   const scrollToBottom = useCallback(() => {
@@ -270,7 +334,7 @@ ${calendarInstruction}The user hasn't told you what they want to work on yet. As
         className="flex-1 overflow-y-auto px-6 py-4 space-y-3"
         data-testid="chat-messages"
       >
-        {/* Empty state */}
+        {/* Empty state with time-of-day prompt and quick-start templates */}
         {messages.length === 0 && (
           <motion.div
             initial={{ opacity: 0 }}
@@ -279,12 +343,36 @@ ${calendarInstruction}The user hasn't told you what they want to work on yet. As
             className="flex flex-col items-center justify-center h-full text-center"
           >
             <div className="spotlight-warm absolute inset-0 pointer-events-none" />
-            <p className="text-txt-secondary text-sm mb-1">
-              What&apos;s on the schedule?
+            <p className="text-txt-secondary text-sm mb-1" data-testid="time-of-day-greeting">
+              {timePrompt.greeting}
             </p>
             <p className="text-txt-muted text-xs">
-              Tell me about your day and I&apos;ll build your lineup.
+              {timePrompt.sub}
             </p>
+
+            {/* Quick-start templates */}
+            <div className="mt-6 flex flex-col gap-2 w-full max-w-xs" data-testid="quick-start-templates">
+              <button
+                onClick={() => {
+                  sendMessage(`I want a light day — 2-3 gentle acts, low pressure. Energy: ${energy ?? 'low'}`)
+                }}
+                className="text-left px-3 py-2 rounded-lg border border-surface-hover/60 text-xs text-txt-secondary hover:text-txt-primary hover:border-accent/30 hover:bg-surface-hover/40 transition-colors"
+                data-testid="template-light"
+              >
+                <span className="font-medium text-txt-primary">Light day</span>
+                <span className="text-txt-muted ml-2">2–3 gentle acts, low pressure</span>
+              </button>
+              <button
+                onClick={() => {
+                  sendMessage(`I want a deep focus day — long deep work blocks, minimal context switching. Energy: ${energy ?? 'high'}`)
+                }}
+                className="text-left px-3 py-2 rounded-lg border border-surface-hover/60 text-xs text-txt-secondary hover:text-txt-primary hover:border-accent/30 hover:bg-surface-hover/40 transition-colors"
+                data-testid="template-deep-focus"
+              >
+                <span className="font-medium text-txt-primary">Deep focus day</span>
+                <span className="text-txt-muted ml-2">Long deep work blocks</span>
+              </button>
+            </div>
           </motion.div>
         )}
 

--- a/src/shared/db-path.ts
+++ b/src/shared/db-path.ts
@@ -1,0 +1,41 @@
+/**
+ * Cross-context DB path resolution.
+ *
+ * Resolves the showtime.db path in both Electron main process
+ * and standalone Node.js/CLI contexts (e.g., skills).
+ */
+import { join } from 'path'
+import { homedir } from 'os'
+
+/**
+ * Resolve the path to showtime.db.
+ *
+ * - Electron main: uses app.getPath('userData')
+ * - Node.js/CLI: uses ~/Library/Application Support/showtime/ (macOS)
+ */
+export function resolveDbPath(): string {
+  // Try Electron's app module first
+  try {
+    // Dynamic require to avoid bundling issues in non-Electron contexts
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { app } = require('electron')
+    if (app && typeof app.getPath === 'function') {
+      return join(app.getPath('userData'), 'showtime.db')
+    }
+  } catch {
+    // Not in Electron context — fall through to Node.js resolution
+  }
+
+  // Node.js/CLI fallback: match Electron's userData path on macOS
+  // Electron uses ~/Library/Application Support/<app-name>/
+  // The app name in package.json is "showtime"
+  const platform = process.platform
+  if (platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support', 'showtime', 'showtime.db')
+  }
+  if (platform === 'win32') {
+    return join(process.env.APPDATA || join(homedir(), 'AppData', 'Roaming'), 'showtime', 'showtime.db')
+  }
+  // Linux
+  return join(process.env.XDG_CONFIG_HOME || join(homedir(), '.config'), 'showtime', 'showtime.db')
+}

--- a/src/shared/showtime-db.ts
+++ b/src/shared/showtime-db.ts
@@ -1,0 +1,179 @@
+/**
+ * Lightweight shared DB access for Showtime.
+ *
+ * Provides read/write access to showtime.db from both the Electron
+ * main process and standalone Node.js contexts (skills, CLI tools).
+ *
+ * Uses better-sqlite3 directly (synchronous) with the same schema
+ * as the main app's Drizzle ORM definitions.
+ */
+import Database from 'better-sqlite3'
+import { existsSync } from 'fs'
+import { resolveDbPath } from './db-path'
+
+// ─── Types ───
+
+export interface ShowRecord {
+  id: string
+  phase: string
+  energy: string | null
+  verdict: string | null
+  beatsLocked: number
+  beatThreshold: number
+  startedAt: number | null
+  endedAt: number | null
+  planText: string | null
+}
+
+export interface ActRecord {
+  id: string
+  showId: string
+  name: string
+  sketch: string
+  category: string | null
+  plannedDurationMs: number
+  actualDurationMs: number | null
+  sortOrder: number
+  status: string
+  beatLocked: number
+  plannedStartAt: number | null
+  actualStartAt: number | null
+  actualEndAt: number | null
+}
+
+export interface TodayShow {
+  show: ShowRecord
+  acts: ActRecord[]
+}
+
+export interface LineupAct {
+  name: string
+  sketch: string
+  durationMinutes: number
+  reason?: string
+}
+
+export interface Lineup {
+  acts: LineupAct[]
+  beatThreshold: number
+  openingNote?: string
+}
+
+// ─── DB Access ───
+
+function openDb(dbPath?: string): Database.Database {
+  const path = dbPath ?? resolveDbPath()
+  const db = new Database(path)
+  db.pragma('journal_mode = WAL')
+  db.pragma('foreign_keys = ON')
+  return db
+}
+
+/**
+ * Read today's show and acts from the database.
+ * Returns null if no show exists for today or if the DB file doesn't exist.
+ */
+export function readToday(dbPath?: string): TodayShow | null {
+  const path = dbPath ?? resolveDbPath()
+  if (!existsSync(path)) return null
+
+  const db = openDb(path)
+  try {
+    const today = new Date().toISOString().slice(0, 10)
+    const show = db.prepare(`
+      SELECT id, phase, energy, verdict,
+        beats_locked AS beatsLocked,
+        beat_threshold AS beatThreshold,
+        started_at AS startedAt,
+        ended_at AS endedAt,
+        plan_text AS planText
+      FROM shows WHERE id = ?
+    `).get(today) as ShowRecord | undefined
+    if (!show) return null
+
+    const acts = db.prepare(`
+      SELECT id, show_id AS showId, name, sketch, category,
+        planned_duration_ms AS plannedDurationMs,
+        actual_duration_ms AS actualDurationMs,
+        sort_order AS sortOrder,
+        status,
+        beat_locked AS beatLocked,
+        planned_start_at AS plannedStartAt,
+        actual_start_at AS actualStartAt,
+        actual_end_at AS actualEndAt
+      FROM acts WHERE show_id = ? ORDER BY sort_order ASC
+    `).all(today) as ActRecord[]
+    return { show, acts }
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * Write a lineup to the database, creating or updating today's show.
+ * Replaces any existing acts for today.
+ */
+export function writeLineup(lineup: Lineup, energy?: string, dbPath?: string): void {
+  const path = dbPath ?? resolveDbPath()
+  const db = openDb(path)
+
+  try {
+    const today = new Date().toISOString().slice(0, 10)
+
+    db.exec('BEGIN')
+    try {
+      // Upsert show
+      db.prepare(`
+        INSERT INTO shows (id, phase, energy, beats_locked, beat_threshold, started_at)
+        VALUES (?, 'writers_room', ?, 0, ?, NULL)
+        ON CONFLICT(id) DO UPDATE SET
+          energy = excluded.energy,
+          beat_threshold = excluded.beat_threshold
+      `).run(today, energy ?? null, lineup.beatThreshold)
+
+      // Clear existing acts for today
+      db.prepare('DELETE FROM acts WHERE show_id = ?').run(today)
+
+      // Insert new acts
+      const insertAct = db.prepare(`
+        INSERT INTO acts (id, show_id, name, sketch, planned_duration_ms, sort_order, status, beat_locked)
+        VALUES (?, ?, ?, ?, ?, ?, 'pending', 0)
+      `)
+      for (let i = 0; i < lineup.acts.length; i++) {
+        const act = lineup.acts[i]
+        const id = Math.random().toString(36).slice(2, 10)
+        insertAct.run(id, today, act.name, act.sketch, act.durationMinutes * 60 * 1000, i)
+      }
+
+      // Save opening note as plan text if provided
+      if (lineup.openingNote) {
+        db.prepare('UPDATE shows SET plan_text = ? WHERE id = ?').run(lineup.openingNote, today)
+      }
+
+      db.exec('COMMIT')
+    } catch (e) {
+      db.exec('ROLLBACK')
+      throw e
+    }
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * Get the current phase of today's show.
+ * Returns null if no show exists for today.
+ */
+export function getPhase(dbPath?: string): string | null {
+  const path = dbPath ?? resolveDbPath()
+  if (!existsSync(path)) return null
+
+  const db = openDb(path)
+  try {
+    const today = new Date().toISOString().slice(0, 10)
+    const row = db.prepare('SELECT phase FROM shows WHERE id = ?').get(today) as { phase: string } | undefined
+    return row?.phase ?? null
+  } finally {
+    db.close()
+  }
+}

--- a/src/skills/showtime/SKILL.md
+++ b/src/skills/showtime/SKILL.md
@@ -9,6 +9,35 @@ You are the **Showtime Director**, an AI day-planning companion that uses the Sa
 
 ---
 
+## Database Integration (Shared SQLite)
+
+On invocation, check the shared Showtime database for today's show state:
+
+```typescript
+import { readToday, getPhase, writeLineup } from '../../shared/showtime-db'
+
+const todayShow = readToday()
+```
+
+**Behavior based on DB state:**
+
+| State | Action |
+|-------|--------|
+| No show exists for today | Energy check → build lineup → write to DB via `writeLineup()` |
+| Show exists, phase = `writers_room` | Present current lineup, offer to refine |
+| Show exists, phase = `live` | Show current act, offer to adjust remaining lineup |
+| Show exists, phase = `strike` | Show completed summary, offer encore (new show) |
+
+After generating or refining a lineup, write it to the database:
+
+```typescript
+writeLineup(lineup, energy)
+```
+
+This ensures both the Electron app and the skill always see the same show state.
+
+---
+
 ## Usage Examples
 
 Generate a lineup from Claude Code by describing your energy, available time, and tasks:


### PR DESCRIPTION
## Summary
- **Part A (Hydration #135):** DarkStudioView detects today's persisted show and shows "Resume Today's Show" button with progress summary. WritersRoomView adds time-of-day contextual prompts (morning/midday/late/evening) and quick-start templates (Light day, Deep focus day).
- **Part B (Shared DB #125):** New `src/shared/db-path.ts` resolves DB path across Electron and Node.js contexts. New `src/shared/showtime-db.ts` provides `readToday()`, `writeLineup()`, `getPhase()` for shared access to showtime.db. SKILL.md updated with DB integration.
- 4 new test files (37 new tests), all 615 tests passing, build succeeds.

## Test plan
- [x] `npm test` — 615 tests pass (36 files)
- [x] `npm run build` — Electron app builds successfully
- [x] `node e2e/capture-evidence.mjs` — screenshots captured
- [ ] Manual: launch app → verify "Resume Today's Show" button appears after exiting mid-show
- [ ] Manual: verify time-of-day greeting changes based on clock
- [ ] Manual: verify quick-start template buttons send correct messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Show resumption: Users can now resume today's show directly from the home screen with saved progress.
  * Time-of-day greetings: Dynamic greeting messages and quick-start templates ("Light day," "Deep focus day") now adjust based on the current time.
  * Strike mode detection: App recognizes and displays strike status for shows.

* **Tests**
  * Added comprehensive test coverage for database operations, show detection, time-based features, and path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->