### PR TITLE
feat: wave quick wins — --bare flag, smoke checklist, PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- Brief description of what this PR does and why -->
+
+## Checklist
+
+- [ ] If this PR changes user flow in a view, I verified the XState machine accepts all events the view sends from the state the user will actually be in
+- [ ] If this PR modifies `showMachine.ts`, I ran the state coverage report (`bun run scripts/state-coverage-report.ts`) and checked for orphaned transitions
+- [ ] If this PR adds a new full-screen view, it is a state in the XState machine (not `useState` routing)
+- [ ] No inline `style={{}}` objects — all styling uses Tailwind utility classes
+- [ ] E2E test coverage added or updated for changed user flows
+- [ ] Animations use spring physics only (no linear transitions)
+
+## Test Evidence
+
+<!-- Paste Playwright screenshots or test output here -->

--- a/.wishloop/state.json
+++ b/.wishloop/state.json
@@ -1,0 +1,1 @@
+{"phase": 5, "phaseLabel": "Execute", "change": "wave-quick-wins", "startedAt": "2026-04-06T18:03:52Z"}

--- a/openspec/changes/wave-quick-wins/proposal.md
+++ b/openspec/changes/wave-quick-wins/proposal.md
@@ -1,0 +1,68 @@
+# Wave: Quick Wins (#111, #173, #174)
+
+## Problem
+
+Three small, independent issues that can be resolved in parallel with minimal risk.
+
+## Goals
+
+1. **#111 — `--bare` flag for Claude subprocess**: Add `'--bare'` to the args array in `src/main/claude/run-manager.ts` for ~10x faster subprocess startup. One-line change in two methods.
+2. **#173 — Manual smoke test checklist**: Create `scripts/manual-smoke.md` with the 5 critical user flows for post-merge verification.
+3. **#174 — PR template checklist**: Add XState transition audit checklist to `.github/PULL_REQUEST_TEMPLATE.md`.
+
+## Scope
+
+### In scope
+- Add `--bare` to `startRun()` and `preWarm()` args in `run-manager.ts`
+- Create `scripts/manual-smoke.md` with 5 critical flows
+- Create or update `.github/PULL_REQUEST_TEMPLATE.md` with XState checklist
+
+### Out of scope
+- Changing pty-run-manager.ts (interactive sessions need full context)
+- Automated enforcement of checklist items
+
+## Testing Strategy
+
+- Run existing E2E tests to verify `--bare` doesn't break subprocess communication
+- Verify the smoke test checklist covers the flows listed in issue #173
+- Verify PR template renders correctly on GitHub
+
+## Acceptance Criteria
+
+- [ ] `--bare` flag added to `run-manager.ts` `startRun()` args
+- [ ] `--bare` flag added to `run-manager.ts` `preWarm()` args
+- [ ] `scripts/manual-smoke.md` exists with 5 critical flows
+- [ ] `.github/PULL_REQUEST_TEMPLATE.md` exists with XState transition audit checklist
+- [ ] Existing tests pass with `--bare` flag
+
+## Context (auto-generated)
+
+### Relevant file paths
+- `src/main/claude/run-manager.ts:327-334` — `startRun()` args array, add `'--bare'` after `-p`
+- `src/main/claude/run-manager.ts:185-192` — `preWarm()` args array, add `'--bare'` after `-p`
+- `src/main/claude/pty-run-manager.ts` — DO NOT modify (interactive sessions)
+- `.github/PULL_REQUEST_TEMPLATE.md` — create if not exists
+
+### CLAUDE.md rules that apply
+- Rule #6: Testing — Playwright E2E is mandatory
+- Rule #8: XState v5 — every full-screen view must be a state in the machine
+- Git workflow: all changes through PRs, never push to main
+
+### Build/run/test commands
+```bash
+npm run build        # Build the Electron app
+npm run test         # Vitest unit tests
+npm run test:e2e     # Playwright E2E tests
+```
+
+### Recent git history for relevant files
+```
+3e45068 fix: move History/Settings/Onboarding to XState overlay region (#205)
+80bc07e feat: mid-show lineup editing via Director Mode (#190) (#191)
+```
+
+### Tech stack
+- Electron + React 19 + TypeScript
+- XState v5 for state management
+- Playwright for E2E testing
+- Vitest for unit tests

--- a/scripts/manual-smoke.md
+++ b/scripts/manual-smoke.md
@@ -1,0 +1,47 @@
+# Manual Smoke Test Checklist
+
+Run these 5 flows after every merge to main. Each takes ~30 seconds.
+These catch layout, animation, and UX bugs that automated tests miss.
+
+## Flow 1: Fresh Start (Dark Studio -> Live)
+
+- [ ] Launch app -> Dark Studio loads (spotlight visible)
+- [ ] Click to enter Writer's Room
+- [ ] Select energy level
+- [ ] Type a plan in chat -> Claude returns lineup
+- [ ] Lineup card appears with acts
+- [ ] Click "Finalize Lineup" -> confirmation panel
+- [ ] Click "Confirm & Go Live" -> GoingLive transition -> live phase
+
+## Flow 2: Resume Existing Lineup
+
+- [ ] Launch app with an existing day's lineup in SQLite
+- [ ] App auto-resumes into live phase (not Writer's Room)
+- [ ] Acts visible in lineup panel
+
+## Flow 3: Live Show Cycle
+
+- [ ] Active act timer counts down
+- [ ] Complete act -> Beat Check modal appears
+- [ ] Lock or skip beat -> next act starts
+- [ ] Verify act card status updates in lineup
+
+## Flow 4: Intermission
+
+- [ ] Trigger intermission (via Director Mode or natural break)
+- [ ] "WE'LL BE RIGHT BACK" card visible
+- [ ] Resume from intermission -> returns to live phase
+
+## Flow 5: Strike the Stage
+
+- [ ] Complete all acts (or strike early via Director Mode)
+- [ ] Strike view shows stats + verdict
+- [ ] Beat count and act recap visible
+- [ ] Reset -> returns to Dark Studio
+
+## Quick Checks (visual)
+
+- [ ] Pill view: timer readable, tally light visible, not collapsed
+- [ ] Expanded view: no overflow, ON AIR bar visible
+- [ ] Settings accessible from all views (gear icon)
+- [ ] Theme toggle works (dark -> light -> dark)

--- a/src/main/claude/run-manager.ts
+++ b/src/main/claude/run-manager.ts
@@ -184,6 +184,7 @@ export class RunManager extends EventEmitter {
 
     const args: string[] = [
       '-p',
+      '--bare',
       '--input-format', 'stream-json',
       '--output-format', 'stream-json',
       '--verbose',
@@ -326,6 +327,7 @@ export class RunManager extends EventEmitter {
 
     const args: string[] = [
       '-p',
+      '--bare',
       '--input-format', 'stream-json',
       '--output-format', 'stream-json',
       '--verbose',


### PR DESCRIPTION
## Summary

- **#111**: Add `--bare` flag to Claude subprocess args in `run-manager.ts` (`startRun` + `preWarm`) for ~10x faster startup. Does NOT apply to `pty-run-manager.ts` (interactive sessions).
- **#173**: Create `scripts/manual-smoke.md` with 5 critical post-merge verification flows (Dark Studio→Live, Resume, Live Cycle, Intermission, Strike).
- **#174**: Create `.github/PULL_REQUEST_TEMPLATE.md` with XState transition audit checklist.

Closes #111, closes #173, closes #174

## Test plan

- [x] Build passes (`npm run build`)
- [x] 834 unit tests pass (`npm run test`)
- [ ] Verify `--bare` doesn't break subprocess communication (E2E with real Claude)
- [ ] PR template renders on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pull request review template with standardized guidelines
  * Added manual smoke test checklist documenting critical application workflows
  * Updated subprocess configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->