### PR TITLE
docs: fix stale internal docs inherited from CLUI CC

### DIFF
--- a/docs/concepts/director-mode.md
+++ b/docs/concepts/director-mode.md
@@ -14,9 +14,17 @@ Director Mode can be triggered when:
 
 You can also open Director Mode yourself at any time. You don't have to wait for the app to suggest it.
 
-## The four options
+## The six options
 
-Director Mode presents four choices. All of them are valid. None of them is failure.
+Director Mode presents six choices. All of them are valid. None of them is failure.
+
+### Edit the lineup
+
+*"The plan needs adjusting."*
+
+Sometimes the lineup you built this morning doesn't match this afternoon's reality. Meetings got added, energy shifted, priorities changed. The Director can reopen the lineup for editing — add acts, remove acts, reorder the sequence — without resetting the whole show.
+
+This is the most common Director action. It's not a sign the original plan was bad. It's a sign the Director is paying attention.
 
 ### Skip to next Act
 
@@ -49,6 +57,14 @@ There is no timer on this break. There is no limit. Rest costs zero, and that's 
 Not a break. Not an intermission. Just five minutes where the only instruction is to breathe. The screen goes calm. The clock pauses. Nothing is expected of you.
 
 Sometimes the ADHD brain doesn't need a strategy or a pivot. It needs five minutes where nobody -- including itself -- is asking it to do anything.
+
+### Reset today's show
+
+*"Start fresh. Clean slate."*
+
+Sometimes the show has gone so far off-script that patching it isn't the right call. The Director can reset the entire show — clear the lineup, reset the timer, wipe the beats — and start over from Dark Studio.
+
+This requires confirmation (it can't be undone). But it's there because sometimes the most compassionate thing is a clean start, not a rescue mission.
 
 ## Why this works
 

--- a/docs/plans/writers-room-state-machine.md
+++ b/docs/plans/writers-room-state-machine.md
@@ -1,5 +1,22 @@
 # Writer's Room State Machine
 
+## Terminology Bridge
+
+This doc uses UX-level names. Here's how they map to XState machine states (`showMachine.ts`):
+
+| UX Name | XState State Path | Phase |
+|---------|-------------------|-------|
+| DARK_STUDIO | `phase.no_show` | `no_show` |
+| WRITERS_ROOM_INIT | `phase.writers_room.energy` | `writers_room` |
+| SKELETON_LINEUP | `phase.writers_room.plan` | `writers_room` |
+| WRITERS_WORKING | `phase.writers_room.plan` (Claude streaming) | `writers_room` |
+| CLAUDE_STREAMING | `phase.writers_room.plan` (lineup parsing) | `writers_room` |
+| LINEUP_READY | `phase.writers_room.lineup_ready` | `writers_room` |
+| GOING_LIVE | `phase.going_live` | `going_live` |
+| ON_AIR | `phase.live` | `live` |
+
+The XState machine groups SKELETON_LINEUP, WRITERS_WORKING, and CLAUDE_STREAMING into a single `plan` substate — the UX distinctions exist in component rendering logic, not in the state machine.
+
 ## States
 
 ```text


### PR DESCRIPTION
## Summary

- Delete stale CLUI CC docs from `docs-internal/` (ARCHITECTURE.md, AGENTS.md, oss-readiness-report.md) — these described the upstream fork's multi-tab/marketplace architecture, not Showtime. They were gitignored so deletion is local-only.
- Add 2 missing Director Mode options to `docs/concepts/director-mode.md`: "Edit the lineup" (EDIT_LINEUP) and "Reset today's show" (RESET). Code has 6 options but doc only listed 4.
- Add terminology bridge table to `docs/plans/writers-room-state-machine.md` mapping UX names (DARK_STUDIO, LINEUP_READY) to XState state paths (phase.no_show, phase.writers_room.lineup_ready).

Closes #208

## Test plan

- [x] Docs build correctly
- [x] Director Mode options match code (`src/renderer/components/DirectorMode.tsx`)
- [x] State machine bridge matches `showMachine.ts` state definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)