### PR TITLE
fix: energy chip reset, missing settings button, dropped first click

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -127,6 +127,14 @@ export default function App() {
             activeTabId: tabId,
             tabReady: true,
           }))
+          // Flush any prompts queued before tab was ready
+          const pending = useSessionStore.getState().pendingPrompts
+          if (pending.length > 0) {
+            useSessionStore.setState({ pendingPrompts: [] })
+            for (const p of pending) {
+              useSessionStore.getState().sendMessage(p.prompt, p.options)
+            }
+          }
           // Warm up immediately after tab is created — don't wait for Writer's Room
           window.showtime.initSession(tabId)
         }).catch(() => {})

--- a/src/renderer/components/ViewMenu.tsx
+++ b/src/renderer/components/ViewMenu.tsx
@@ -11,7 +11,7 @@ import {
 import { cn } from '../lib/utils'
 
 interface ViewMenuProps {
-  view: 'pill' | 'compact' | 'expanded'
+  view: 'pill' | 'compact' | 'expanded' | 'writers_room'
 }
 
 export function ViewMenu({ view }: ViewMenuProps) {

--- a/src/renderer/stores/sessionStore.ts
+++ b/src/renderer/stores/sessionStore.ts
@@ -28,6 +28,8 @@ interface State {
   activeTabId: string
   /** True once createTab() has resolved and the tab ID is valid in ControlPlane */
   tabReady: boolean
+  /** Prompts queued before tabReady — flushed when tab becomes ready */
+  pendingPrompts: Array<{ prompt: string; options?: { projectPath?: string; displayText?: string; maxTurns?: number } }>
   isExpanded: boolean
   staticInfo: StaticInfo | null
   preferredModel: string | null
@@ -103,6 +105,7 @@ export const useSessionStore = create<State>((set, get) => ({
   tabs: [initialTab],
   activeTabId: initialTab.id,
   tabReady: false,
+  pendingPrompts: [],
   isExpanded: false,
   staticInfo: null,
   preferredModel: null,
@@ -177,7 +180,8 @@ export const useSessionStore = create<State>((set, get) => ({
     const maxTurns = options?.maxTurns
     const { activeTabId, tabs, staticInfo, tabReady } = get()
     if (!tabReady) {
-      window.showtime.logEvent('WARN', 'sendMessage.dropped', { reason: 'tab not ready yet', activeTabId })
+      window.showtime.logEvent('INFO', 'sendMessage.queued', { reason: 'tab not ready yet', activeTabId })
+      set((s) => ({ pendingPrompts: [...s.pendingPrompts, { prompt, options }] }))
       return
     }
     const tab = tabs.find((t) => t.id === activeTabId)

--- a/src/renderer/views/WritersRoomView.tsx
+++ b/src/renderer/views/WritersRoomView.tsx
@@ -8,6 +8,7 @@ import { tryParseCalendarEvents } from '../lib/calendar-parser'
 import { ChatMessage } from '../components/ChatMessage'
 import { ActCard } from '../components/ActCard'
 import { CalendarToggle } from '../components/CalendarToggle'
+import { ViewMenu } from '../components/ViewMenu'
 import { ProgressiveLoader } from '../components/ProgressiveLoader'
 import { Button } from '../ui/button'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -142,10 +143,11 @@ export function WritersRoomView() {
     scrollToBottom()
   }, [messages.length, scrollToBottom])
 
-  // Default energy to medium if not set
+  // Default energy to medium if not set (mount-only — deps would reset on every XState cycle)
   useEffect(() => {
     if (!energy) setEnergy('medium')
-  }, [energy, setEnergy])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   // Pre-warm Claude subprocess when Writer's Room mounts
   useEffect(() => {
@@ -305,6 +307,8 @@ export function WritersRoomView() {
           </div>
 
           {/* Calendar toggle hidden in chat-first mode — Claude handles calendar via MCP */}
+
+          <ViewMenu view="writers_room" />
 
           {/* Close button */}
           <button


### PR DESCRIPTION
## Summary
- **#224**: Energy chip always shows 'medium' — `useEffect` had `[energy, setEnergy]` deps causing reset on every XState context cycle. Changed to mount-only `[]`.
- **#225**: Settings/menu button missing from Writer's Room — added `ViewMenu` component to header, matching PillView and ExpandedView patterns.
- **#226**: First energy button click dropped silently when tab not ready — added `pendingPrompts` queue to sessionStore, flushed when `createTab` resolves instead of silently discarding.

Closes #224, #225, #226

## Test plan
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] All 853 unit tests pass
- [ ] E2E: Verify energy chip retains user selection after picking
- [ ] E2E: Verify settings gear visible in Writer's Room header
- [ ] E2E: Verify first energy click works during warmup (queued and delivered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)