### PR TITLE
fix: make toolbar buttons consistent across all views

### DIFF
--- a/src/renderer/components/ViewMenu.tsx
+++ b/src/renderer/components/ViewMenu.tsx
@@ -11,7 +11,7 @@ import {
 import { cn } from '../lib/utils'
 
 interface ViewMenuProps {
-  view: 'pill' | 'compact' | 'expanded' | 'writers_room'
+  view: 'pill' | 'compact' | 'dashboard' | 'expanded' | 'writers_room' | 'strike'
 }
 
 /** Dropdown menu providing quick access to show controls, navigation, and view switching. */

--- a/src/renderer/views/CompactView.tsx
+++ b/src/renderer/views/CompactView.tsx
@@ -8,6 +8,7 @@ import { BeatCounter } from '../components/BeatCounter'
 import { OnAirIndicator } from '../components/OnAirIndicator'
 import { RundownBar } from '../components/RundownBar'
 import { ViewMenu } from '../components/ViewMenu'
+import { MuteToggle } from '../components/MuteToggle'
 import { cn } from '../lib/utils'
 
 function formatStartTime(timestamp: number): string {
@@ -89,6 +90,7 @@ export function CompactView() {
             </>
           )}
         </div>
+        <MuteToggle />
         <ViewMenu
           view="compact"
         />
@@ -97,6 +99,13 @@ export function CompactView() {
           className="px-1 py-0.5 text-txt-muted hover:text-txt-secondary transition-colors no-drag text-xs"
         >
           ▼
+        </button>
+        <button
+          onClick={() => window.showtime.quit()}
+          className="px-1 py-0.5 text-txt-muted hover:text-onair transition-colors text-xs no-drag"
+          title="Quit Showtime"
+        >
+          ✕
         </button>
       </div>
 

--- a/src/renderer/views/DashboardView.tsx
+++ b/src/renderer/views/DashboardView.tsx
@@ -9,6 +9,7 @@ import { OnAirIndicator } from '../components/OnAirIndicator'
 import { RundownBar } from '../components/RundownBar'
 import { ClapperboardBadge } from '../components/ClapperboardBadge'
 import { MuteToggle } from '../components/MuteToggle'
+import { ViewMenu } from '../components/ViewMenu'
 import { cn } from '../lib/utils'
 import { formatDateLabel } from '../lib/utils'
 import { getCategoryClasses } from '../lib/category-colors'
@@ -80,6 +81,7 @@ export function DashboardView() {
         >
           Director
         </button>
+        <ViewMenu view="dashboard" />
         <button
           onClick={collapseViewTier}
           className="px-1 py-0.5 text-txt-muted hover:text-txt-secondary transition-colors no-drag text-xs"

--- a/src/renderer/views/HistoryView.tsx
+++ b/src/renderer/views/HistoryView.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { localToday } from '../../shared/date-utils'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Button } from '../ui/button'
 import { cn } from '../lib/utils'
 import type { ShowHistoryEntry, ShowDetailEntry, ActSnapshot } from '../../shared/types'
 
@@ -268,12 +267,6 @@ export function HistoryView({ onBack }: HistoryViewProps) {
         })}
       </div>
 
-      {/* Footer */}
-      <div className="px-5 py-4 border-t border-[#242428]">
-        <Button variant="neutral" onClick={onBack}>
-          Back to Stage
-        </Button>
-      </div>
     </motion.div>
   )
 }

--- a/src/renderer/views/StrikeView.tsx
+++ b/src/renderer/views/StrikeView.tsx
@@ -6,6 +6,8 @@ import { OnAirIndicator } from '../components/OnAirIndicator'
 import { BeatCounter } from '../components/BeatCounter'
 import { Button } from '../ui/button'
 import { motion } from 'framer-motion'
+import { MuteToggle } from '../components/MuteToggle'
+import { ViewMenu } from '../components/ViewMenu'
 import { cn } from '../lib/utils'
 import { playAudioCue } from '../hooks/useAudio'
 
@@ -60,6 +62,8 @@ export function StrikeView() {
         </span>
         <div className="flex items-center gap-1">
           <OnAirIndicator isLive={false} />
+          <MuteToggle />
+          <ViewMenu view="strike" />
           <button
             onClick={() => setViewTier('micro')}
             className="px-2 py-1.5 text-txt-muted hover:text-txt-secondary transition-colors no-drag"

--- a/src/renderer/views/WritersRoomView.tsx
+++ b/src/renderer/views/WritersRoomView.tsx
@@ -9,6 +9,7 @@ import { EnergyPicker } from '../components/EnergyPicker'
 import { LineupDraftPreview, LineupConfirmation } from '../components/LineupPreview'
 import { ChatInput } from '../components/ChatInput'
 import { ViewMenu } from '../components/ViewMenu'
+import { MuteToggle } from '../components/MuteToggle'
 import { ProgressiveLoader } from '../components/ProgressiveLoader'
 import { motion } from 'framer-motion'
 import { formatDateLabel } from '../lib/utils'
@@ -257,6 +258,8 @@ export function WritersRoomView() {
               setEnergyPickerOpen(false)
             }}
           />
+
+          <MuteToggle />
 
           <ViewMenu view="writers_room" />
 


### PR DESCRIPTION
## Summary
Toolbar buttons were inconsistent across views — some full-size views were missing close, ViewMenu, or MuteToggle controls.

Closes #237

## Changes
- **CompactView**: Added MuteToggle + close button
- **DashboardView**: Added ViewMenu
- **StrikeView**: Added MuteToggle + ViewMenu
- **WritersRoomView**: Added MuteToggle
- **HistoryView**: Removed duplicate footer back button
- **ViewMenu**: Extended view prop type for dashboard + strike

## Test plan
- [x] TypeScript type-check passes
- [x] All 933 unit tests pass
- [ ] Visual: verify all full-size views show close, ViewMenu, MuteToggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mute toggle controls in Compact, Strike, and Writers Room views for audio management
  * Introduced view mode selector in Dashboard and Strike views
  * Added quick-exit button in Compact view for immediate app shutdown

* **UI/UX Improvements**
  * Simplified History view navigation by removing redundant back button

<!-- end of auto-generated comment: release notes by coderabbit.ai -->