### PR TITLE
fix: show Edit Lineup and Take a Break in Director Mode menu

### DIFF
--- a/src/renderer/components/ViewMenu.tsx
+++ b/src/renderer/components/ViewMenu.tsx
@@ -23,9 +23,9 @@ export function ViewMenu({ view }: ViewMenuProps) {
   const enterDirector = useCallback(() => send({ type: 'ENTER_DIRECTOR' }), [send])
   const enterIntermission = useCallback(() => send({ type: 'ENTER_INTERMISSION' }), [send])
 
-  const canEditLineup = phase === 'live' || phase === 'intermission'
+  const canEditLineup = phase === 'live' || phase === 'intermission' || phase === 'director'
   const canDirector = phase === 'live' || phase === 'intermission'
-  const canBreak = phase === 'live'
+  const canBreak = phase === 'live' || phase === 'director'
 
   const isPill = view === 'pill'
 


### PR DESCRIPTION
## Summary
Edit Lineup and Take a Break menu items disappeared when in Director Mode because the phase guards didn't include `'director'`.

Closes #246

## Changes
- `ViewMenu.tsx`: Added `|| phase === 'director'` to `canEditLineup` and `canBreak` guards

One-line fix. 999/999 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled "Edit Lineup" action during director mode.
  * Enabled "Take a Break" action during director mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->