### PR TITLE
chore: add SessionStart hook for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -29,6 +29,20 @@ fi
 echo "==> Attempting Electron native rebuild (needed for E2E tests)..."
 if npm run postinstall --silent; then
   echo "    Electron native modules rebuilt successfully."
+
+  # `npm install --ignore-scripts` above skipped the `electron` package's own
+  # postinstall, which downloads the Electron binary into
+  # node_modules/electron/dist. Without that binary, `_electron.launch()` in
+  # Playwright fails with "Electron failed to install correctly". Trigger it
+  # explicitly here (idempotent — the installer no-ops if dist/ already exists).
+  if [ ! -x node_modules/electron/dist/electron ]; then
+    echo "==> Downloading Electron binary..."
+    if node node_modules/electron/install.js; then
+      echo "    Electron binary downloaded."
+    else
+      echo "    ⚠ Electron binary download failed; Playwright E2E tests will not run." >&2
+    fi
+  fi
 else
   cat <<'EOF'
     ⚠ Electron native rebuild skipped (network policy likely blocks

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -19,7 +19,12 @@ echo "==> Installing Node dependencies..."
 npm install --no-audit --no-fund --ignore-scripts
 
 echo "==> Rebuilding better-sqlite3 for system Node (vitest)..."
-npm rebuild better-sqlite3 --silent || true
+if npm rebuild better-sqlite3 --silent; then
+  echo "    better-sqlite3 rebuilt successfully."
+else
+  rc=$?
+  echo "    ⚠ better-sqlite3 rebuild failed (exit $rc); vitest may fail for sqlite-backed tests. Try: npm rebuild better-sqlite3" >&2
+fi
 
 echo "==> Attempting Electron native rebuild (needed for E2E tests)..."
 if npm run postinstall --silent; then
@@ -39,7 +44,8 @@ fi
 # Playwright's _electron.launch() inherits a working X display when the
 # agent wraps test commands with `xvfb-run -a`.
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-  echo "export DISPLAY=:99" >> "$CLAUDE_ENV_FILE"
+  grep -qxF "export DISPLAY=:99" "$CLAUDE_ENV_FILE" 2>/dev/null \
+    || echo "export DISPLAY=:99" >> "$CLAUDE_ENV_FILE"
 fi
 
 echo "==> Setup complete."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Installs Node dependencies so vitest, eslint, and (when the network policy
+# allows it) the Playwright/Electron E2E suite can run in a fresh container.
+# Skipped on local runs — developers manage their own env there.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+echo "==> Installing Node dependencies..."
+# Skip the package's postinstall first — electron-builder install-app-deps
+# fetches Electron headers from electronjs.org, which most network policies
+# block. We try a best-effort rebuild against Electron afterwards.
+npm install --no-audit --no-fund --ignore-scripts
+
+echo "==> Rebuilding better-sqlite3 for system Node (vitest)..."
+npm rebuild better-sqlite3 --silent || true
+
+echo "==> Attempting Electron native rebuild (needed for E2E tests)..."
+if npm run postinstall --silent; then
+  echo "    Electron native modules rebuilt successfully."
+else
+  cat <<'EOF'
+    ⚠ Electron native rebuild skipped (network policy likely blocks
+      electronjs.org — node-gyp can't fetch Electron headers). Vitest and
+      ESLint will still work. To unlock Playwright/Electron E2E tests, widen
+      the environment's network policy to allow electronjs.org, then re-run:
+        npm run postinstall
+EOF
+fi
+
+# Showtime is a macOS product, but its Electron binary runs on Linux under
+# Xvfb (xvfb-run is preinstalled in the container). Persist DISPLAY so
+# Playwright's _electron.launch() inherits a working X display when the
+# agent wraps test commands with `xvfb-run -a`.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export DISPLAY=:99" >> "$CLAUDE_ENV_FILE"
+fi
+
+echo "==> Setup complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh\""
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "matcher": "",


### PR DESCRIPTION
## Summary

Adds a `SessionStart` hook so future Claude Code on the web sessions for Showtime get a working test/lint environment without any local setup. The hook is a no-op locally (`$CLAUDE_CODE_REMOTE != true`); only cloud containers run the installer.

## Why split the install?

The cloud container's default network policy blocks `electronjs.org`, and the package's `postinstall` (`electron-builder install-app-deps`) needs Electron headers from there to rebuild `node-pty` against the Electron ABI. To stay useful even with that restriction:

1. `npm install --ignore-scripts` — always succeeds, populates `node_modules`.
2. `npm rebuild better-sqlite3` — rebuilt against system Node so vitest can load it.
3. `npm run postinstall` — best-effort Electron rebuild. On failure the hook prints a diagnostic explaining what to widen to unlock the E2E path, then exits 0.
4. Persists `DISPLAY=:99` to `$CLAUDE_ENV_FILE` so Playwright's `_electron.launch()` finds an X display when the agent wraps tests with `xvfb-run -a`.

## Files

- `.claude/hooks/session-start.sh` (new, executable)
- `.claude/settings.json` — registers the hook alongside the existing `Stop` hooks

## Test plan

- [x] Hook runs end-to-end with `CLAUDE_CODE_REMOTE=true` — exits 0 even when Electron rebuild fails
- [x] `npx eslint src/shared/date-utils.ts` — clean
- [x] `npx vitest run src/__tests__/constants.test.ts` — 11/11 passed
- [x] `$CLAUDE_ENV_FILE` receives `export DISPLAY=:99`
- [x] Confirmed resume behavior in a real `SessionStart:resume` event after push

## Notes for reviewers

- Synchronous execution by design — guarantees deps before any tool call, at the cost of ~30–60s startup. Trivial to flip to async (`{"async": true, "asyncTimeout": 300000}`) if startup latency becomes a problem.
- To unlock Playwright/Electron E2E in cloud sessions, allow `electronjs.org` in the environment's network policy, then `npm run postinstall` will succeed on the next session.

https://claude.ai/code/session_01S1yHHhPXqLJyuWEmTG2iSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1yHHhPXqLJyuWEmTG2iSM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated session initialization that prepares the project environment, installs dependencies, and attempts native module rebuilds for smoother startup.
  * Improved support for headless/testing environments by ensuring display settings are configured when needed and emitting guidance if external native component downloads are blocked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vishnujayvel/showtime/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->